### PR TITLE
Implement frontend endpoints, narratives

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - /home/coder/postgresql/data:/var/lib/postgresql/data
+      - ./postgresql/data:/var/lib/postgresql/data
     environment:
       - POSTGRES_PASSWORD=s3cret
       - POSTGRES_USER=pas

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - ./postgresql/data:/var/lib/postgresql/data
+      - /home/coder/postgresql/data:/var/lib/postgresql/data
     environment:
       - POSTGRES_PASSWORD=s3cret
       - POSTGRES_USER=pas

--- a/core/app.py
+++ b/core/app.py
@@ -13,13 +13,15 @@ from psycopg_pool import AsyncConnectionPool
 
 from core.auth import base_guard
 from core.migrate import migrate
-from core.videos.claims.controller import ClaimController
+from core.narratives.controller import NarrativeController
+from core.topics.controller import TopicController
+from core.videos.claims.controller import ClaimController, RootClaimController
 from core.videos.controller import VideoController
 from core.videos.transcripts.controller import TranscriptController
 
 load_dotenv()
 
-MIGRATION_TARGET_VERSION = 4
+MIGRATION_TARGET_VERSION = 9
 DB_HOST = os.environ.get("DATABASE_HOST")
 DB_PORT = os.environ.get("DATABASE_PORT")
 DB_USER = os.environ.get("DATABASE_USER")
@@ -78,6 +80,9 @@ api_router = Router(
         VideoController,
         TranscriptController,
         ClaimController,
+        RootClaimController,
+        NarrativeController,
+        TopicController,
     ],
 )
 

--- a/core/cli.py
+++ b/core/cli.py
@@ -1,0 +1,104 @@
+import asyncio
+import os
+import sys
+from urllib.parse import urljoin
+
+import click
+import httpx
+from dotenv import load_dotenv
+
+from core.app import pool_factory, postgres_url
+from core.videos.claims.repo import ClaimRepository
+
+
+load_dotenv()
+
+
+async def fetch_claims(limit: int = 400):
+    """Fetch the first 400 claims from the database."""
+    pool = pool_factory(postgres_url)
+    await pool.open()
+    try:
+        async with pool.connection() as conn:
+            async with conn.cursor() as cur:
+                repo = ClaimRepository(cur)
+                claims, _ = await repo.get_all_claims(limit=limit, offset=0)
+                return claims
+    finally:
+        await pool.close()
+
+
+async def initialize_dashboard(claims):
+    """Send claims to the narratives dashboard API."""
+    narratives_base_endpoint = os.environ.get("NARRATIVES_BASE_ENDPOINT")
+    narratives_api_key = os.environ.get("NARRATIVES_API_KEY")
+    app_base_url = os.environ.get("APP_BASE_URL")
+    
+    if not narratives_base_endpoint or not narratives_api_key or not app_base_url:
+        click.echo("Error: NARRATIVES_BASE_ENDPOINT, NARRATIVES_API_KEY, and APP_BASE_URL must be set", err=True)
+        sys.exit(1)
+    
+    # Generate the absolute API endpoint URLs with placeholders
+    claim_api_url = urljoin(app_base_url, "/api/videos/{video_id}/claims/{claim_id}")
+    narratives_api_url = urljoin(app_base_url, "/api/narratives")
+    
+    # Prepare the request payload
+    payload = {
+        "claims": [
+            {
+                "claim": claim.claim,
+                "id": str(claim.id),
+                "video_id": str(claim.video_id) if claim.video_id else None
+            }
+            for claim in claims
+        ],
+        "narratives_api_url": narratives_api_url,
+        "claim_api_url": claim_api_url
+    }
+    
+    # Send POST request to initialize-dashboard endpoint
+    url = urljoin(narratives_base_endpoint, "/initialize-dashboard")
+    headers = {
+        "X-API-TOKEN": narratives_api_key,
+        "Content-Type": "application/json"
+    }
+    
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers, timeout=60.0)
+            response.raise_for_status()
+            click.echo(f"Successfully initialized dashboard with {len(claims)} claims")
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            click.echo(f"Error: HTTP {e.response.status_code} - {e.response.text}", err=True)
+            sys.exit(1)
+        except Exception as e:
+            click.echo(f"Error: {e}", err=True)
+            sys.exit(1)
+
+
+@click.command()
+@click.argument('num_claims', type=int, default=400)
+def start_narratives(num_claims):
+    """Extract claims from the database and initialize the narratives dashboard.
+    
+    NUM_CLAIMS: Number of claims to fetch (default: 400)
+    """
+    async def main():
+        click.echo(f"Fetching {num_claims} claims from database...")
+        claims = await fetch_claims(num_claims)
+        click.echo(f"Found {len(claims)} claims")
+        
+        if not claims:
+            click.echo("No claims found in database", err=True)
+            return
+        
+        click.echo("Initializing narratives dashboard...")
+        result = await initialize_dashboard(claims)
+        click.echo("Dashboard initialization complete!")
+    
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    start_narratives()

--- a/core/migrations/5.add-narratives-table.up.sql
+++ b/core/migrations/5.add-narratives-table.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS narratives (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    title text NOT NULL,
+    description text NOT NULL,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMIT;

--- a/core/migrations/6.add-topics-table.up.sql
+++ b/core/migrations/6.add-topics-table.up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS topics (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    topic text NOT NULL UNIQUE,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS narrative_topics (
+    narrative_id uuid REFERENCES narratives(id) ON DELETE CASCADE,
+    topic_id uuid REFERENCES topics(id) ON DELETE CASCADE,
+    PRIMARY KEY (narrative_id, topic_id)
+);
+
+COMMIT;

--- a/core/migrations/7.add-claim-narratives-table.up.sql
+++ b/core/migrations/7.add-claim-narratives-table.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS claim_narratives (
+    claim_id uuid REFERENCES video_claims(id) ON DELETE CASCADE,
+    narrative_id uuid REFERENCES narratives(id) ON DELETE CASCADE,
+    PRIMARY KEY (claim_id, narrative_id)
+);
+
+CREATE INDEX idx_claim_narratives_claim_id ON claim_narratives(claim_id);
+CREATE INDEX idx_claim_narratives_narrative_id ON claim_narratives(narrative_id);
+
+COMMIT;

--- a/core/migrations/8.insert-default-topics.up.sql
+++ b/core/migrations/8.insert-default-topics.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- We're also inserting the ID here because those are hardcoded in our narratives system for the MVP
+INSERT INTO topics (id, topic, metadata) VALUES
+    ('db3d996b-e691-4ce5-8c46-e35a82a9b28c', 'Climate', '{}'),
+    ('bb52f622-b9ee-4d5b-9b70-5fd05046528b', 'Health', '{}'),
+    ('3cd4a9cd-5906-4b0b-9167-57ff22c2345a', 'Migration', '{}'),
+    ('0d7aaf8d-5b7e-4c0c-b03a-28457e27ac7d', 'Conflicts', '{}'),
+    ('ff1bedb9-43e4-49e6-9c3f-27babfb7bfa1', 'European Union', '{}')
+ON CONFLICT (id) DO NOTHING;
+
+COMMIT;

--- a/core/migrations/9.add-claim-topics-table.up.sql
+++ b/core/migrations/9.add-claim-topics-table.up.sql
@@ -1,0 +1,11 @@
+-- Create the many-to-many relationship table between claims and topics
+CREATE TABLE IF NOT EXISTS claim_topics (
+    claim_id UUID NOT NULL REFERENCES video_claims(id) ON DELETE CASCADE,
+    topic_id UUID NOT NULL REFERENCES topics(id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    PRIMARY KEY (claim_id, topic_id)
+);
+
+-- Create indexes for faster lookups
+CREATE INDEX idx_claim_topics_claim_id ON claim_topics(claim_id);
+CREATE INDEX idx_claim_topics_topic_id ON claim_topics(topic_id);

--- a/core/narratives/controller.py
+++ b/core/narratives/controller.py
@@ -1,0 +1,117 @@
+from typing import Any
+from uuid import UUID
+
+from litestar import Controller, delete, get, patch, post
+from litestar.di import Provide
+from litestar.dto import DTOData
+from litestar.exceptions import NotFoundException
+
+from core.errors import ConflictError
+from core.response import JSON
+from core.uow import ConnectionFactory
+from core.narratives.models import Narrative, NarrativeInput, NarrativeDTO
+from core.narratives.service import NarrativeService
+
+
+async def narrative_service(
+    connection_factory: ConnectionFactory,
+) -> NarrativeService:
+    return NarrativeService(connection_factory=connection_factory)
+
+
+class NarrativeController(Controller):
+    path = "/narratives"
+    tags = ["narratives"]
+
+    dependencies = {
+        "narrative_service": Provide(narrative_service),
+    }
+
+    @post(
+        path="/",
+        summary="Create a new narrative",
+        dto=NarrativeDTO,
+        return_dto=None,
+        raises=[ConflictError],
+    )
+    async def create_narrative(
+        self,
+        narrative_service: NarrativeService,
+        data: DTOData[NarrativeInput],
+    ) -> JSON[Narrative]:
+        return JSON(await narrative_service.create_narrative(data))
+
+    @get(
+        path="/{narrative_id:uuid}",
+        summary="Get a specific narrative",
+    )
+    async def get_narrative(
+        self, narrative_service: NarrativeService, narrative_id: UUID
+    ) -> JSON[Narrative]:
+        narrative = await narrative_service.get_narrative(narrative_id)
+        if not narrative:
+            raise NotFoundException()
+        return JSON(narrative)
+
+    @get(
+        path="/",
+        summary="Get all narratives",
+    )
+    async def get_narratives(
+        self,
+        narrative_service: NarrativeService,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> JSON[list[Narrative]]:
+        return JSON(
+            await narrative_service.get_all_narratives(limit=limit, offset=offset)
+        )
+
+    @get(
+        path="/claims/{claim_id:uuid}",
+        summary="Get all narratives for a specific claim",
+    )
+    async def get_narratives_by_claim(
+        self, narrative_service: NarrativeService, claim_id: UUID
+    ) -> JSON[list[Narrative]]:
+        return JSON(await narrative_service.get_narratives_by_claim(claim_id))
+
+    @patch(
+        path="/{narrative_id:uuid}",
+        summary="Update a narrative",
+        dto=NarrativeDTO,
+        return_dto=None,
+    )
+    async def update_narrative(
+        self,
+        narrative_service: NarrativeService,
+        narrative_id: UUID,
+        data: DTOData[NarrativeInput],
+    ) -> JSON[Narrative]:
+        narrative = await narrative_service.update_narrative(narrative_id, data)
+        if not narrative:
+            raise NotFoundException()
+        return JSON(narrative)
+
+    @patch(
+        path="/{narrative_id:uuid}/metadata",
+        summary="Update the metadata for a narrative",
+    )
+    async def patch_narrative_metadata(
+        self,
+        narrative_service: NarrativeService,
+        narrative_id: UUID,
+        data: dict[str, Any],
+    ) -> JSON[dict[str, Any]]:
+        return JSON(await narrative_service.update_metadata(narrative_id, data))
+
+    @delete(
+        path="/{narrative_id:uuid}",
+        summary="Delete a specific narrative",
+    )
+    async def delete_narrative(
+        self,
+        narrative_service: NarrativeService,
+        narrative_id: UUID,
+    ) -> None:
+        await narrative_service.delete_narrative(narrative_id)

--- a/core/narratives/controller.py
+++ b/core/narratives/controller.py
@@ -76,6 +76,36 @@ class NarrativeController(Controller):
     ) -> JSON[list[Narrative]]:
         return JSON(await narrative_service.get_narratives_by_claim(claim_id))
 
+    @get(
+        path="/viral",
+        summary="Get viral narratives from a specified time period sorted by views",
+    )
+    async def get_viral_narratives(
+        self,
+        narrative_service: NarrativeService,
+        limit: int = 100,
+        offset: int = 0,
+        hours: int = 24,
+    ) -> JSON[list[Narrative]]:
+        return JSON(
+            await narrative_service.get_viral_narratives(limit=limit, offset=offset, hours=hours)
+        )
+
+    @get(
+        path="/prevalent",
+        summary="Get prevalent narratives sorted by video count in a specified time period",
+    )
+    async def get_prevalent_narratives(
+        self,
+        narrative_service: NarrativeService,
+        limit: int = 100,
+        offset: int = 0,
+        hours: int = 24,
+    ) -> JSON[list[Narrative]]:
+        return JSON(
+            await narrative_service.get_prevalent_narratives(limit=limit, offset=offset, hours=hours)
+        )
+
     @patch(
         path="/{narrative_id:uuid}",
         summary="Update a narrative",

--- a/core/narratives/models.py
+++ b/core/narratives/models.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from litestar.dto import DTOConfig
+from litestar.plugins.pydantic import PydanticDTO
+from pydantic import BaseModel, Field
+
+from core.topics.models import Topic
+from core.videos.claims.models import Claim
+
+
+class Narrative(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    title: str
+    description: str
+    claims: list[Claim] = Field(default_factory=list)
+    topics: list[Topic] = Field(default_factory=list)
+    videos: list[Any] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class NarrativeInput(BaseModel):
+    title: str
+    description: str
+    claim_ids: list[UUID] = Field(default_factory=list)
+    topic_ids: list[UUID] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class NarrativeDTO(PydanticDTO[NarrativeInput]):
+    config = DTOConfig(
+        exclude={
+            "id",
+            "created_at",
+            "updated_at",
+        },
+    )

--- a/core/narratives/repo.py
+++ b/core/narratives/repo.py
@@ -1,0 +1,343 @@
+from typing import Any
+from uuid import UUID
+
+import psycopg
+from psycopg.rows import DictRow
+from psycopg.types.json import Jsonb
+
+from core.errors import ConflictError
+from core.narratives.models import Narrative
+from core.topics.models import Topic
+from core.videos.claims.models import Claim
+from core.videos.models import Video
+
+
+class NarrativeRepository:
+    def __init__(self, session: psycopg.AsyncCursor[DictRow]) -> None:
+        self._session = session
+
+    async def create_narrative(
+        self,
+        title: str,
+        description: str,
+        claim_ids: list[UUID],
+        topic_ids: list[UUID],
+        metadata: dict[str, Any],
+    ) -> Narrative:
+        try:
+            await self._session.execute(
+                """
+                INSERT INTO narratives (
+                    title, description, metadata
+                ) VALUES (
+                    %(title)s, %(description)s, %(metadata)s
+                )
+                RETURNING *
+                """,
+                {
+                    "title": title,
+                    "description": description,
+                    "metadata": Jsonb(metadata),
+                },
+            )
+        except psycopg.errors.UniqueViolation:
+            raise ConflictError("narrative already exists")
+
+        row = await self._session.fetchone()
+        if not row:
+            raise ValueError("failed to create narrative")
+
+        narrative_id = row["id"]
+
+        if claim_ids:
+            await self._session.executemany(
+                """
+                INSERT INTO claim_narratives (claim_id, narrative_id)
+                VALUES (%(claim_id)s, %(narrative_id)s)
+                """,
+                [
+                    {"claim_id": claim_id, "narrative_id": narrative_id}
+                    for claim_id in claim_ids
+                ],
+            )
+
+        if topic_ids:
+            await self._session.executemany(
+                """
+                INSERT INTO narrative_topics (narrative_id, topic_id)
+                VALUES (%(narrative_id)s, %(topic_id)s)
+                """,
+                [
+                    {"narrative_id": narrative_id, "topic_id": topic_id}
+                    for topic_id in topic_ids
+                ],
+            )
+
+        claims = await self._get_narrative_claims(narrative_id)
+        topics = await self._get_narrative_topics(narrative_id)
+        videos = await self._get_narrative_videos(narrative_id)
+
+        return Narrative(**row, claims=claims, topics=topics, videos=videos)
+
+    async def get_narrative(self, narrative_id: UUID) -> Narrative | None:
+        await self._session.execute(
+            """
+            SELECT * FROM narratives
+            WHERE id = %(narrative_id)s
+            """,
+            {"narrative_id": narrative_id},
+        )
+        row = await self._session.fetchone()
+        if not row:
+            return None
+
+        claims = await self._get_narrative_claims(narrative_id)
+        topics = await self._get_narrative_topics(narrative_id)
+        videos = await self._get_narrative_videos(narrative_id)
+        return Narrative(**row, claims=claims, topics=topics, videos=videos)
+
+    async def get_narratives_by_claim(self, claim_id: UUID) -> list[Narrative]:
+        await self._session.execute(
+            """
+            SELECT * FROM narratives
+            WHERE claim_id = %(claim_id)s
+            ORDER BY created_at DESC
+            """,
+            {"claim_id": claim_id},
+        )
+        rows = await self._session.fetchall()
+
+        narratives = []
+        for row in rows:
+            claims = await self._get_narrative_claims(row["id"])
+            topics = await self._get_narrative_topics(row["id"])
+            videos = await self._get_narrative_videos(row["id"])
+            narratives.append(Narrative(**row, claims=claims, topics=topics, videos=videos))
+
+        return narratives
+
+    async def get_all_narratives(
+        self, limit: int = 100, offset: int = 0
+    ) -> list[Narrative]:
+        await self._session.execute(
+            """
+            SELECT * FROM narratives
+            ORDER BY created_at DESC
+            LIMIT %(limit)s OFFSET %(offset)s
+            """,
+            {"limit": limit, "offset": offset},
+        )
+        rows = await self._session.fetchall()
+
+        narratives = []
+        for row in rows:
+            claims = await self._get_narrative_claims(row["id"])
+            topics = await self._get_narrative_topics(row["id"])
+            videos = await self._get_narrative_videos(row["id"])
+            narratives.append(Narrative(**row, claims=claims, topics=topics, videos=videos))
+
+        return narratives
+
+    async def update_narrative(
+        self,
+        narrative_id: UUID,
+        title: str | None = None,
+        description: str | None = None,
+        claim_ids: list[UUID] | None = None,
+        topic_ids: list[UUID] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Narrative | None:
+        updates = []
+        params = {"narrative_id": narrative_id}
+
+        if title is not None:
+            updates.append("title = %(title)s")
+            params["title"] = title
+
+        if description is not None:
+            updates.append("description = %(description)s")
+            params["description"] = description
+
+        if metadata is not None:
+            updates.append("metadata = metadata || %(metadata)s")
+            params["metadata"] = Jsonb(metadata)
+
+        if updates:
+            updates.append("updated_at = now()")
+            await self._session.execute(
+                f"""
+                UPDATE narratives
+                SET {", ".join(updates)}
+                WHERE id = %(narrative_id)s
+                RETURNING *
+                """,
+                params,
+            )
+            row = await self._session.fetchone()
+            if not row:
+                return None
+        else:
+            await self._session.execute(
+                """
+                SELECT * FROM narratives
+                WHERE id = %(narrative_id)s
+                """,
+                {"narrative_id": narrative_id},
+            )
+            row = await self._session.fetchone()
+            if not row:
+                return None
+
+        if claim_ids is not None:
+            await self._session.execute(
+                """
+                DELETE FROM claim_narratives
+                WHERE narrative_id = %(narrative_id)s
+                """,
+                {"narrative_id": narrative_id},
+            )
+
+            if claim_ids:
+                await self._session.executemany(
+                    """
+                    INSERT INTO claim_narratives (claim_id, narrative_id)
+                    VALUES (%(claim_id)s, %(narrative_id)s)
+                    """,
+                    [
+                        {"claim_id": claim_id, "narrative_id": narrative_id}
+                        for claim_id in claim_ids
+                    ],
+                )
+
+        if topic_ids is not None:
+            await self._session.execute(
+                """
+                DELETE FROM narrative_topics
+                WHERE narrative_id = %(narrative_id)s
+                """,
+                {"narrative_id": narrative_id},
+            )
+
+            if topic_ids:
+                await self._session.executemany(
+                    """
+                    INSERT INTO narrative_topics (narrative_id, topic_id)
+                    VALUES (%(narrative_id)s, %(topic_id)s)
+                    """,
+                    [
+                        {"narrative_id": narrative_id, "topic_id": topic_id}
+                        for topic_id in topic_ids
+                    ],
+                )
+
+        claims = await self._get_narrative_claims(narrative_id)
+        topics = await self._get_narrative_topics(narrative_id)
+        videos = await self._get_narrative_videos(narrative_id)
+        return Narrative(**row, claims=claims, topics=topics, videos=videos)
+
+    async def delete_narrative(self, narrative_id: UUID) -> None:
+        await self._session.execute(
+            """
+            DELETE FROM narratives WHERE id = %(narrative_id)s
+            """,
+            {"narrative_id": narrative_id},
+        )
+
+    async def _get_narrative_claims(self, narrative_id: UUID) -> list[Claim]:
+        await self._session.execute(
+            """
+            SELECT c.id, c.video_id, c.claim, c.start_time_s, c.metadata, c.created_at, c.updated_at
+            FROM video_claims c
+            JOIN claim_narratives cn ON c.id = cn.claim_id
+            WHERE cn.narrative_id = %(narrative_id)s
+            ORDER BY c.start_time_s
+            """,
+            {"narrative_id": narrative_id},
+        )
+        return [Claim(**row) for row in await self._session.fetchall()]
+
+    async def _get_narrative_topics(self, narrative_id: UUID) -> list[Topic]:
+        await self._session.execute(
+            """
+            SELECT t.*
+            FROM topics t
+            JOIN narrative_topics nt ON t.id = nt.topic_id
+            WHERE nt.narrative_id = %(narrative_id)s
+            ORDER BY t.topic
+            """,
+            {"narrative_id": narrative_id},
+        )
+        return [Topic(**row) for row in await self._session.fetchall()]
+
+    async def _get_narrative_videos(self, narrative_id: UUID) -> list[Video]:
+        await self._session.execute(
+            """
+            SELECT DISTINCT v.id, v.title, v.description, v.platform, v.source_url, 
+                   v.destination_path, v.uploaded_at, v.views, v.likes, v.comments, 
+                   v.channel, v.channel_followers, v.scrape_topic, v.scrape_keyword, 
+                   v.metadata, v.created_at, v.updated_at
+            FROM videos v
+            JOIN video_claims c ON v.id = c.video_id
+            JOIN claim_narratives cn ON c.id = cn.claim_id
+            WHERE cn.narrative_id = %(narrative_id)s
+            ORDER BY v.uploaded_at DESC
+            """,
+            {"narrative_id": narrative_id},
+        )
+        rows = await self._session.fetchall()
+        videos = []
+        for row in rows:
+            video_data = dict(row)
+            video_data['embedding'] = None  # Exclude embedding data
+            videos.append(Video(**video_data))
+        return videos
+
+    async def claims_exist(self, claim_ids: list[UUID]) -> bool:
+        if not claim_ids:
+            return True
+        
+        await self._session.execute(
+            """
+            SELECT COUNT(*) as count FROM video_claims WHERE id = ANY(%(claim_ids)s)
+            """,
+            {"claim_ids": claim_ids},
+        )
+        row = await self._session.fetchone()
+        return row["count"] == len(claim_ids)
+    
+    async def get_narratives_by_topic(
+        self, topic_id: UUID, limit: int = 100, offset: int = 0
+    ) -> tuple[list[Narrative], int]:
+        # Get total count
+        await self._session.execute(
+            """
+            SELECT COUNT(DISTINCT n.id) 
+            FROM narratives n
+            JOIN narrative_topics nt ON n.id = nt.narrative_id
+            WHERE nt.topic_id = %(topic_id)s
+            """,
+            {"topic_id": topic_id},
+        )
+        total_row = await self._session.fetchone()
+        total = total_row["count"] if total_row else 0
+        
+        # Get narratives
+        await self._session.execute(
+            """
+            SELECT DISTINCT n.*
+            FROM narratives n
+            JOIN narrative_topics nt ON n.id = nt.narrative_id
+            WHERE nt.topic_id = %(topic_id)s
+            ORDER BY n.created_at DESC
+            LIMIT %(limit)s OFFSET %(offset)s
+            """,
+            {"topic_id": topic_id, "limit": limit, "offset": offset},
+        )
+        narratives = []
+        for row in await self._session.fetchall():
+            claims = await self._get_narrative_claims(row["id"])
+            topics = await self._get_narrative_topics(row["id"])
+            videos = await self._get_narrative_videos(row["id"])
+            narratives.append(Narrative(**row, claims=claims, topics=topics, videos=videos))
+        
+        return narratives, total

--- a/core/narratives/service.py
+++ b/core/narratives/service.py
@@ -1,0 +1,88 @@
+from typing import Any, AsyncContextManager
+from uuid import UUID
+
+from litestar.dto import DTOData
+
+from core.uow import ConnectionFactory, uow
+from core.narratives.models import Narrative, NarrativeInput
+from core.narratives.repo import NarrativeRepository
+
+
+class NarrativeService:
+    def __init__(self, connection_factory: ConnectionFactory) -> None:
+        self._connection_factory = connection_factory
+
+    def repo(self) -> AsyncContextManager[NarrativeRepository]:
+        return uow(NarrativeRepository, self._connection_factory)
+
+    async def create_narrative(
+        self, narrative: NarrativeInput | DTOData[NarrativeInput]
+    ) -> Narrative:
+        if isinstance(narrative, DTOData):
+            narrative = narrative.create_instance()
+        
+        async with self.repo() as repo:
+            if not await repo.claims_exist(narrative.claim_ids):
+                raise ValueError("one or more claims not found")
+            
+            return await repo.create_narrative(
+                title=narrative.title,
+                description=narrative.description,
+                claim_ids=narrative.claim_ids,
+                topic_ids=narrative.topic_ids,
+                metadata=narrative.metadata,
+            )
+
+    async def get_narrative(self, narrative_id: UUID) -> Narrative | None:
+        async with self.repo() as repo:
+            return await repo.get_narrative(narrative_id)
+
+    async def get_narratives_by_claim(self, claim_id: UUID) -> list[Narrative]:
+        async with self.repo() as repo:
+            return await repo.get_narratives_by_claim(claim_id)
+
+    async def get_all_narratives(
+        self, limit: int = 100, offset: int = 0
+    ) -> list[Narrative]:
+        async with self.repo() as repo:
+            return await repo.get_all_narratives(limit=limit, offset=offset)
+
+    async def update_narrative(
+        self,
+        narrative_id: UUID,
+        data: dict[str, Any] | DTOData[NarrativeInput],
+    ) -> Narrative | None:
+        if isinstance(data, DTOData):
+            data = data.as_builtins()
+        
+        async with self.repo() as repo:
+            return await repo.update_narrative(
+                narrative_id=narrative_id,
+                title=data.get("title"),
+                description=data.get("description"),
+                claim_ids=data.get("claim_ids"),
+                topic_ids=data.get("topic_ids"),
+                metadata=data.get("metadata"),
+            )
+
+    async def delete_narrative(self, narrative_id: UUID) -> None:
+        async with self.repo() as repo:
+            await repo.delete_narrative(narrative_id)
+
+    async def update_metadata(
+        self, narrative_id: UUID, metadata: dict[str, Any]
+    ) -> dict[str, Any]:
+        async with self.repo() as repo:
+            updated = await repo.update_narrative(
+                narrative_id=narrative_id,
+                metadata=metadata,
+            )
+            if not updated:
+                raise ValueError("narrative not found")
+            return updated.metadata
+    
+    async def get_narratives_by_topic(
+        self, topic_id: UUID, limit: int = 100, offset: int = 0
+    ) -> tuple[list[Narrative], int]:
+        async with self.repo() as repo:
+            return await repo.get_narratives_by_topic(topic_id, limit=limit, offset=offset)

--- a/core/narratives/service.py
+++ b/core/narratives/service.py
@@ -86,3 +86,15 @@ class NarrativeService:
     ) -> tuple[list[Narrative], int]:
         async with self.repo() as repo:
             return await repo.get_narratives_by_topic(topic_id, limit=limit, offset=offset)
+    
+    async def get_viral_narratives(
+        self, limit: int = 100, offset: int = 0, hours: int = 24
+    ) -> list[Narrative]:
+        async with self.repo() as repo:
+            return await repo.get_viral_narratives(limit=limit, offset=offset, hours=hours)
+    
+    async def get_prevalent_narratives(
+        self, limit: int = 100, offset: int = 0, hours: int = 24
+    ) -> list[Narrative]:
+        async with self.repo() as repo:
+            return await repo.get_prevalent_narratives(limit=limit, offset=offset, hours=hours)

--- a/core/response.py
+++ b/core/response.py
@@ -21,6 +21,16 @@ class CursorJSON(JSON[T]):
 
 
 @dataclass
+class PaginatedJSON(Generic[T]):
+    """Base response structure for paginated API responses with count."""
+
+    data: T
+    total: int
+    page: int
+    size: int
+
+
+@dataclass
 class Error:
     status: int
     message: str

--- a/core/topics/controller.py
+++ b/core/topics/controller.py
@@ -1,0 +1,224 @@
+from typing import Any
+from uuid import UUID
+
+from litestar import Controller, delete, get, patch, post
+from litestar.di import Provide
+from litestar.dto import DTOData
+from litestar.exceptions import NotFoundException
+
+from core.errors import ConflictError
+from core.response import JSON, PaginatedJSON
+from core.uow import ConnectionFactory
+from core.narratives.models import Narrative
+from core.narratives.service import NarrativeService
+from core.topics.models import Topic, TopicDTO, TopicWithStats
+from core.topics.service import TopicService
+from core.videos.claims.models import Claim
+from core.videos.claims.service import ClaimsService
+
+
+async def topic_service(
+    connection_factory: ConnectionFactory,
+) -> TopicService:
+    return TopicService(connection_factory=connection_factory)
+
+
+async def narrative_service(
+    connection_factory: ConnectionFactory,
+) -> NarrativeService:
+    return NarrativeService(connection_factory=connection_factory)
+
+
+async def claims_service(
+    connection_factory: ConnectionFactory,
+) -> ClaimsService:
+    return ClaimsService(connection_factory=connection_factory)
+
+
+class TopicController(Controller):
+    path = "/topics"
+    tags = ["topics"]
+
+    dependencies = {
+        "topic_service": Provide(topic_service),
+        "narrative_service": Provide(narrative_service),
+        "claims_service": Provide(claims_service),
+    }
+
+    @post(
+        path="/",
+        summary="Create a new topic",
+        dto=TopicDTO,
+        return_dto=None,
+        raises=[ConflictError],
+    )
+    async def create_topic(
+        self,
+        topic_service: TopicService,
+        data: DTOData[Topic],
+    ) -> JSON[Topic]:
+        return JSON(await topic_service.create_topic(data))
+
+    @get(
+        path="/{topic_id:uuid}",
+        summary="Get a specific topic",
+    )
+    async def get_topic(
+        self, topic_service: TopicService, topic_id: UUID
+    ) -> JSON[Topic]:
+        topic = await topic_service.get_topic(topic_id)
+        if not topic:
+            raise NotFoundException()
+        return JSON(topic)
+
+    @get(
+        path="/name/{topic:str}",
+        summary="Get a topic by name",
+    )
+    async def get_topic_by_name(
+        self, topic_service: TopicService, topic: str
+    ) -> JSON[Topic]:
+        result = await topic_service.get_topic_by_name(topic)
+        if not result:
+            raise NotFoundException()
+        return JSON(result)
+
+    @get(
+        path="/",
+        summary="Get all topics",
+    )
+    async def get_topics(
+        self,
+        topic_service: TopicService,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> JSON[list[Topic]]:
+        return JSON(
+            await topic_service.get_all_topics(limit=limit, offset=offset)
+        )
+
+    @get(
+        path="/search",
+        summary="Search topics by query",
+    )
+    async def search_topics(
+        self,
+        topic_service: TopicService,
+        query: str,
+    ) -> JSON[list[Topic]]:
+        return JSON(await topic_service.search_topics(query))
+    
+    @get(
+        path="/stats",
+        summary="Get all topics with narrative and claim counts",
+    )
+    async def get_topics_with_stats(
+        self,
+        topic_service: TopicService,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PaginatedJSON[list[TopicWithStats]]:
+        topics, total = await topic_service.get_all_topics_with_stats(
+            limit=limit, offset=offset
+        )
+        page = (offset // limit) + 1 if limit > 0 else 1
+        return PaginatedJSON(
+            data=topics,
+            total=total,
+            page=page,
+            size=limit,
+        )
+
+    @get(
+        path="/narratives/{narrative_id:uuid}",
+        summary="Get topics for a specific narrative",
+    )
+    async def get_topics_by_narrative(
+        self, topic_service: TopicService, narrative_id: UUID
+    ) -> JSON[list[Topic]]:
+        return JSON(await topic_service.get_topics_by_narrative(narrative_id))
+
+    @patch(
+        path="/{topic_id:uuid}",
+        summary="Update a topic",
+        dto=TopicDTO,
+        return_dto=None,
+        raises=[ConflictError],
+    )
+    async def update_topic(
+        self,
+        topic_service: TopicService,
+        topic_id: UUID,
+        data: DTOData[Topic],
+    ) -> JSON[Topic]:
+        topic = await topic_service.update_topic(topic_id, data)
+        if not topic:
+            raise NotFoundException()
+        return JSON(topic)
+
+    @patch(
+        path="/{topic_id:uuid}/metadata",
+        summary="Update the metadata for a topic",
+    )
+    async def patch_topic_metadata(
+        self,
+        topic_service: TopicService,
+        topic_id: UUID,
+        data: dict[str, Any],
+    ) -> JSON[dict[str, Any]]:
+        return JSON(await topic_service.update_metadata(topic_id, data))
+
+    @delete(
+        path="/{topic_id:uuid}",
+        summary="Delete a specific topic",
+    )
+    async def delete_topic(
+        self,
+        topic_service: TopicService,
+        topic_id: UUID,
+    ) -> None:
+        await topic_service.delete_topic(topic_id)
+    
+    @get(
+        path="/{topic_id:uuid}/narratives",
+        summary="Get all narratives for a specific topic",
+    )
+    async def get_narratives_by_topic(
+        self,
+        narrative_service: NarrativeService,
+        topic_id: UUID,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> PaginatedJSON[list[Narrative]]:
+        narratives, total = await narrative_service.get_narratives_by_topic(
+            topic_id, limit=limit, offset=offset
+        )
+        page = (offset // limit) + 1 if limit > 0 else 1
+        return PaginatedJSON(
+            data=narratives,
+            total=total,
+            page=page,
+            size=limit,
+        )
+    
+    @get(
+        path="/{topic_id:uuid}/claims",
+        summary="Get all claims for a specific topic",
+    )
+    async def get_claims_by_topic(
+        self,
+        claims_service: ClaimsService,
+        topic_id: UUID,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> PaginatedJSON[list[Claim]]:
+        claims, total = await claims_service.get_claims_by_topic(
+            topic_id, limit=limit, offset=offset
+        )
+        page = (offset // limit) + 1 if limit > 0 else 1
+        return PaginatedJSON(
+            data=claims,
+            total=total,
+            page=page,
+            size=limit,
+        )

--- a/core/topics/models.py
+++ b/core/topics/models.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from litestar.dto import DTOConfig
+from litestar.plugins.pydantic import PydanticDTO
+from pydantic import BaseModel, Field
+
+
+class Topic(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    topic: str
+    metadata: dict[str, Any] = {}
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class TopicWithStats(Topic):
+    narrative_count: int = 0
+    claim_count: int = 0
+
+
+class TopicDTO(PydanticDTO[Topic]):
+    config = DTOConfig(
+        exclude={
+            "id",
+            "created_at",
+            "updated_at",
+        },
+    )

--- a/core/topics/repo.py
+++ b/core/topics/repo.py
@@ -1,0 +1,177 @@
+from typing import Any
+from uuid import UUID
+
+import psycopg
+from psycopg.rows import DictRow
+from psycopg.types.json import Jsonb
+
+from core.errors import ConflictError
+from core.topics.models import Topic, TopicWithStats
+
+
+class TopicRepository:
+    def __init__(self, session: psycopg.AsyncCursor[DictRow]) -> None:
+        self._session = session
+
+    async def create_topic(
+        self, topic: str, metadata: dict[str, Any]
+    ) -> Topic:
+        try:
+            await self._session.execute(
+                """
+                INSERT INTO topics (topic, metadata)
+                VALUES (%(topic)s, %(metadata)s)
+                RETURNING *
+                """,
+                {
+                    "topic": topic,
+                    "metadata": Jsonb(metadata),
+                },
+            )
+        except psycopg.errors.UniqueViolation:
+            raise ConflictError("topic already exists")
+
+        row = await self._session.fetchone()
+        if not row:
+            raise ValueError("failed to create topic")
+
+        return Topic(**row)
+
+    async def get_topic(self, topic_id: UUID) -> Topic | None:
+        await self._session.execute(
+            """
+            SELECT * FROM topics
+            WHERE id = %(topic_id)s
+            """,
+            {"topic_id": topic_id},
+        )
+        row = await self._session.fetchone()
+        if not row:
+            return None
+        return Topic(**row)
+
+    async def get_topic_by_name(self, topic: str) -> Topic | None:
+        await self._session.execute(
+            """
+            SELECT * FROM topics
+            WHERE topic = %(topic)s
+            """,
+            {"topic": topic},
+        )
+        row = await self._session.fetchone()
+        if not row:
+            return None
+        return Topic(**row)
+
+    async def get_all_topics(
+        self, limit: int = 100, offset: int = 0
+    ) -> list[Topic]:
+        await self._session.execute(
+            """
+            SELECT * FROM topics
+            ORDER BY topic
+            LIMIT %(limit)s OFFSET %(offset)s
+            """,
+            {"limit": limit, "offset": offset},
+        )
+        return [Topic(**row) for row in await self._session.fetchall()]
+
+    async def search_topics(self, query: str) -> list[Topic]:
+        await self._session.execute(
+            """
+            SELECT * FROM topics
+            WHERE topic ILIKE %(query)s
+            ORDER BY topic
+            LIMIT 50
+            """,
+            {"query": f"%{query}%"},
+        )
+        return [Topic(**row) for row in await self._session.fetchall()]
+
+    async def update_topic(
+        self,
+        topic_id: UUID,
+        topic: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Topic | None:
+        updates = []
+        params = {"topic_id": topic_id}
+
+        if topic is not None:
+            updates.append("topic = %(topic)s")
+            params["topic"] = topic
+
+        if metadata is not None:
+            updates.append("metadata = metadata || %(metadata)s")
+            params["metadata"] = Jsonb(metadata)
+
+        if not updates:
+            return await self.get_topic(topic_id)
+
+        updates.append("updated_at = now()")
+        
+        try:
+            await self._session.execute(
+                f"""
+                UPDATE topics
+                SET {", ".join(updates)}
+                WHERE id = %(topic_id)s
+                RETURNING *
+                """,
+                params,
+            )
+        except psycopg.errors.UniqueViolation:
+            raise ConflictError("topic already exists")
+
+        row = await self._session.fetchone()
+        if not row:
+            return None
+        return Topic(**row)
+
+    async def delete_topic(self, topic_id: UUID) -> None:
+        await self._session.execute(
+            """
+            DELETE FROM topics WHERE id = %(topic_id)s
+            """,
+            {"topic_id": topic_id},
+        )
+
+    async def get_topics_by_narrative(self, narrative_id: UUID) -> list[Topic]:
+        await self._session.execute(
+            """
+            SELECT t.*
+            FROM topics t
+            JOIN narrative_topics nt ON t.id = nt.topic_id
+            WHERE nt.narrative_id = %(narrative_id)s
+            ORDER BY t.topic
+            """,
+            {"narrative_id": narrative_id},
+        )
+        return [Topic(**row) for row in await self._session.fetchall()]
+    
+    async def get_all_topics_with_stats(
+        self, limit: int = 100, offset: int = 0
+    ) -> tuple[list[TopicWithStats], int]:
+        # Get total count
+        await self._session.execute("SELECT COUNT(*) FROM topics")
+        total_row = await self._session.fetchone()
+        total = total_row["count"] if total_row else 0
+        
+        # Get topics with stats
+        await self._session.execute(
+            """
+            SELECT 
+                t.*,
+                COUNT(DISTINCT nt.narrative_id) as narrative_count,
+                COUNT(DISTINCT ct.claim_id) as claim_count
+            FROM topics t
+            LEFT JOIN narrative_topics nt ON t.id = nt.topic_id
+            LEFT JOIN claim_topics ct ON t.id = ct.topic_id
+            GROUP BY t.id
+            ORDER BY t.topic
+            LIMIT %(limit)s OFFSET %(offset)s
+            """,
+            {"limit": limit, "offset": offset},
+        )
+        topics = [TopicWithStats(**row) for row in await self._session.fetchall()]
+        return topics, total

--- a/core/topics/service.py
+++ b/core/topics/service.py
@@ -1,0 +1,87 @@
+from typing import Any, AsyncContextManager
+from uuid import UUID
+
+from litestar.dto import DTOData
+
+from core.uow import ConnectionFactory, uow
+from core.topics.models import Topic, TopicWithStats
+from core.topics.repo import TopicRepository
+
+
+class TopicService:
+    def __init__(self, connection_factory: ConnectionFactory) -> None:
+        self._connection_factory = connection_factory
+
+    def repo(self) -> AsyncContextManager[TopicRepository]:
+        return uow(TopicRepository, self._connection_factory)
+
+    async def create_topic(
+        self, topic: Topic | DTOData[Topic]
+    ) -> Topic:
+        if isinstance(topic, DTOData):
+            topic = topic.create_instance()
+        
+        async with self.repo() as repo:
+            return await repo.create_topic(
+                topic=topic.topic,
+                metadata=topic.metadata,
+            )
+
+    async def get_topic(self, topic_id: UUID) -> Topic | None:
+        async with self.repo() as repo:
+            return await repo.get_topic(topic_id)
+
+    async def get_topic_by_name(self, topic: str) -> Topic | None:
+        async with self.repo() as repo:
+            return await repo.get_topic_by_name(topic)
+
+    async def get_all_topics(
+        self, limit: int = 100, offset: int = 0
+    ) -> list[Topic]:
+        async with self.repo() as repo:
+            return await repo.get_all_topics(limit=limit, offset=offset)
+
+    async def search_topics(self, query: str) -> list[Topic]:
+        async with self.repo() as repo:
+            return await repo.search_topics(query)
+
+    async def update_topic(
+        self,
+        topic_id: UUID,
+        data: dict[str, Any] | DTOData[Topic],
+    ) -> Topic | None:
+        if isinstance(data, DTOData):
+            data = data.as_builtins()
+        
+        async with self.repo() as repo:
+            return await repo.update_topic(
+                topic_id=topic_id,
+                topic=data.get("topic"),
+                metadata=data.get("metadata"),
+            )
+
+    async def delete_topic(self, topic_id: UUID) -> None:
+        async with self.repo() as repo:
+            await repo.delete_topic(topic_id)
+
+    async def update_metadata(
+        self, topic_id: UUID, metadata: dict[str, Any]
+    ) -> dict[str, Any]:
+        async with self.repo() as repo:
+            updated = await repo.update_topic(
+                topic_id=topic_id,
+                metadata=metadata,
+            )
+            if not updated:
+                raise ValueError("topic not found")
+            return updated.metadata
+
+    async def get_topics_by_narrative(self, narrative_id: UUID) -> list[Topic]:
+        async with self.repo() as repo:
+            return await repo.get_topics_by_narrative(narrative_id)
+    
+    async def get_all_topics_with_stats(
+        self, limit: int = 100, offset: int = 0
+    ) -> tuple[list[TopicWithStats], int]:
+        async with self.repo() as repo:
+            return await repo.get_all_topics_with_stats(limit=limit, offset=offset)

--- a/core/videos/claims/controller.py
+++ b/core/videos/claims/controller.py
@@ -2,14 +2,17 @@ from typing import Any
 from uuid import UUID
 
 from litestar import Controller, delete, get, patch, post
+from litestar.params import Parameter
 from litestar.di import Provide
 from litestar.dto import DTOData
 from litestar.exceptions import NotFoundException
 
 from core.errors import ConflictError
-from core.response import JSON
+from core.response import JSON, PaginatedJSON
 from core.uow import ConnectionFactory
 from core.videos.claims.models import (
+    Claim,
+    ClaimUpdate,
     VideoClaims,
     VideoClaimsDTO,
 )
@@ -88,3 +91,55 @@ class ClaimController(Controller):
         claim_id: UUID,
     ) -> None:
         await claims_service.delete_claim(claim_id)
+    
+    @patch(
+        path="/{claim_id:uuid}",
+        summary="Update claim associations (topics and entities)",
+    )
+    async def update_claim_associations(
+        self,
+        claims_service: ClaimsService,
+        video_id: UUID,
+        claim_id: UUID,
+        data: ClaimUpdate,
+    ) -> JSON[Claim]:
+        try:
+            updated_claim = await claims_service.update_claim_associations(
+                claim_id=claim_id,
+                topic_ids=data.topics,
+                entity_ids=data.entities if data.entities else None
+            )
+            return JSON(updated_claim)
+        except ValueError:
+            raise NotFoundException()
+
+
+class RootClaimController(Controller):
+    path = "/claims"
+    tags = ["claims"]
+
+    dependencies = {
+        "claims_service": Provide(claims_service),
+    }
+
+    @get(
+        path="/",
+        summary="Get all claims with optional topic filter",
+    )
+    async def get_all_claims(
+        self,
+        claims_service: ClaimsService,
+        topic_id: UUID | None = Parameter(None, query="topic_id"),
+        limit: int = Parameter(100, query="limit", gt=0, le=1000),
+        offset: int = Parameter(0, query="offset", ge=0),
+    ) -> PaginatedJSON[list[Claim]]:
+        claims, total = await claims_service.get_all_claims(
+            limit=limit, offset=offset, topic_id=topic_id
+        )
+        page = (offset // limit) + 1 if limit > 0 else 1
+        return PaginatedJSON(
+            data=claims,
+            total=total,
+            page=page,
+            size=limit,
+        )

--- a/core/videos/claims/models.py
+++ b/core/videos/claims/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -5,13 +6,21 @@ from litestar.dto import DTOConfig
 from litestar.plugins.pydantic import PydanticDTO
 from pydantic import BaseModel, Field
 
+from core.topics.models import Topic
+
 
 class Claim(BaseModel):
     id: UUID = Field(default_factory=uuid4)
+    video_id: UUID | None = None  # Reference to the video
     claim: str  # The claim made in the video
     start_time_s: float  # When in the video the claim starts
     embedding: list[float] | None = None
-    metadata: dict[str, Any] = {}  # Additional metadata about the claim
+    metadata: dict[str, Any] = Field(default_factory=dict)  # Additional metadata about the claim
+    topics: list[Topic] = Field(default_factory=list)  # Associated topics
+    video: Any | None = None  # Video information
+    narratives: list[Any] = Field(default_factory=list)  # Associated narratives
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
 
 
 class VideoClaims(BaseModel):
@@ -26,3 +35,8 @@ class VideoClaimsDTO(PydanticDTO[VideoClaims]):
             "embedding",
         },
     )
+
+
+class ClaimUpdate(BaseModel):
+    entities: list[UUID] = Field(default_factory=list)  # Future entity IDs
+    topics: list[UUID] = Field(default_factory=list)  # Topic IDs to associate

--- a/core/videos/claims/repo.py
+++ b/core/videos/claims/repo.py
@@ -45,7 +45,7 @@ class ClaimRepository:
             row = await self._session.fetchone()
             if not row:
                 break
-            added_claims.append(self._create_claim_from_row(row, None, None, None))
+            added_claims.append(self._create_claim_from_row(row, None, None, None, include_embedding=False))
             if not self._session.nextset():
                 break
 
@@ -61,7 +61,7 @@ class ClaimRepository:
             """,
             {"video_id": video_id},
         )
-        return [self._create_claim_from_row(row, None, None, None) for row in await self._session.fetchall()]
+        return [self._create_claim_from_row(row, None, None, None, include_embedding=False) for row in await self._session.fetchall()]
 
     async def delete_video_claims(self, video_id: UUID) -> None:
         await self._session.execute(
@@ -294,4 +294,6 @@ class ClaimRepository:
             return None
         
         topics = await self._get_claim_topics(claim_id)
-        return self._create_claim_from_row(row, topics, None, None)
+        video = await self._get_video_info(row["video_id"]) if row.get("video_id") else None
+        narratives = await self._get_claim_narratives(claim_id)
+        return self._create_claim_from_row(row, topics, video, narratives, include_embedding=False)

--- a/core/videos/claims/service.py
+++ b/core/videos/claims/service.py
@@ -44,3 +44,40 @@ class ClaimsService:
     async def delete_claim(self, claim_id: UUID) -> None:
         async with self.repo() as repo:
             return await repo.delete_claim(claim_id)
+    
+    async def get_claims_by_topic(
+        self, topic_id: UUID, limit: int = 100, offset: int = 0
+    ) -> tuple[list[Claim], int]:
+        async with self.repo() as repo:
+            return await repo.get_claims_by_topic(topic_id, limit=limit, offset=offset)
+    
+    async def get_all_claims(
+        self, limit: int = 100, offset: int = 0, topic_id: UUID | None = None
+    ) -> tuple[list[Claim], int]:
+        async with self.repo() as repo:
+            return await repo.get_all_claims(limit=limit, offset=offset, topic_id=topic_id)
+    
+    async def associate_topics_with_claim(
+        self, claim_id: UUID, topic_ids: list[UUID]
+    ) -> None:
+        async with self.repo() as repo:
+            await repo.associate_topics_with_claim(claim_id, topic_ids)
+    
+    async def update_claim_associations(
+        self, claim_id: UUID, topic_ids: list[UUID], entity_ids: list[UUID] | None = None
+    ) -> Claim:
+        async with self.repo() as repo:
+            # Check if claim exists
+            claim = await repo.get_claim_by_id(claim_id)
+            if not claim:
+                raise ValueError(f"Claim with ID {claim_id} not found")
+            
+            # Update topic associations
+            await repo.associate_topics_with_claim(claim_id, topic_ids)
+            
+            # TODO: When entities are implemented, update entity associations here
+            # if entity_ids is not None:
+            #     await repo.associate_entities_with_claim(claim_id, entity_ids)
+            
+            # Return updated claim with new associations
+            return await repo.get_claim_by_id(claim_id)

--- a/core/videos/models.py
+++ b/core/videos/models.py
@@ -8,7 +8,7 @@ from litestar.plugins.pydantic import PydanticDTO
 from pydantic import BaseModel, Field
 
 from core.videos.claims.models import VideoClaims
-from core.videos.transcripts.models import Transcript
+from core.videos.transcripts.models import TranscriptResponse
 
 
 class Video(BaseModel):
@@ -30,9 +30,29 @@ class Video(BaseModel):
     metadata: dict[str, Any] = {}
 
 
-class AnalysedVideo(Video):
-    transcript: Transcript | None = None
+class VideoResponse(BaseModel):
+    """Response model for videos without embeddings"""
+    id: UUID
+    title: str
+    description: str
+    platform: str
+    source_url: str
+    destination_path: str
+    uploaded_at: datetime | None
+    views: int | None = None
+    likes: int | None = None
+    comments: int | None = None
+    channel: str | None = None
+    channel_followers: int | None = None
+    scrape_topic: str | None = None
+    scrape_keyword: str | None = None
+    metadata: dict[str, Any] = {}
+
+
+class AnalysedVideo(VideoResponse):
+    transcript: TranscriptResponse | None = None
     claims: VideoClaims | None = None
+    narratives: list[Any] = Field(default_factory=list)
 
 
 class VideoPatch(PydanticDTO[Video]):

--- a/core/videos/repo.py
+++ b/core/videos/repo.py
@@ -207,3 +207,18 @@ class VideoRepository:
         videos = [Video(**row) for row in await self._session.fetchall()]
         
         return videos, total
+    
+    async def get_narratives_for_video(self, video_id: UUID) -> list[dict]:
+        """Get all narratives associated with a video through its claims"""
+        await self._session.execute(
+            """
+            SELECT DISTINCT n.id, n.title, n.description, n.metadata, n.created_at, n.updated_at
+            FROM narratives n
+            JOIN claim_narratives cn ON n.id = cn.narrative_id
+            JOIN video_claims c ON cn.claim_id = c.id
+            WHERE c.video_id = %(video_id)s
+            ORDER BY n.created_at DESC
+            """,
+            {"video_id": video_id},
+        )
+        return [dict(row) for row in await self._session.fetchall()]

--- a/core/videos/service.py
+++ b/core/videos/service.py
@@ -38,3 +38,9 @@ class VideoService:
     async def delete_video(self, video_id) -> None:
         async with self.repo() as repo:
             return await repo.delete_video(video_id)
+
+    async def get_videos_paginated(
+        self, limit: int, offset: int, platform: list[str] | None = None, channel: list[str] | None = None
+    ) -> tuple[list[Video], int]:
+        async with self.repo() as repo:
+            return await repo.get_videos_paginated(limit, offset, platform, channel)

--- a/core/videos/service.py
+++ b/core/videos/service.py
@@ -44,3 +44,7 @@ class VideoService:
     ) -> tuple[list[Video], int]:
         async with self.repo() as repo:
             return await repo.get_videos_paginated(limit, offset, platform, channel)
+    
+    async def get_narratives_for_video(self, video_id: UUID) -> list[dict]:
+        async with self.repo() as repo:
+            return await repo.get_narratives_for_video(video_id)

--- a/core/videos/transcripts/models.py
+++ b/core/videos/transcripts/models.py
@@ -27,3 +27,18 @@ class TranscriptDTO(PydanticDTO[Transcript]):
             "embedding",
         },
     )
+
+
+class TranscriptSentenceResponse(BaseModel):
+    """Response model for transcript sentences without embeddings"""
+    id: UUID
+    source: str
+    text: str
+    start_time_s: float
+    metadata: dict[str, Any] = {}
+
+
+class TranscriptResponse(BaseModel):
+    """Response model for transcripts without embeddings"""
+    video_id: UUID | None
+    sentences: list[TranscriptSentenceResponse]

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -50,11 +50,20 @@ spec:
                 secretKeyRef:
                   name: db
                   key: password
+            - name: NARRATIVES_BASE_ENDPOINT
+              value: https://pas-narratives.fundacionmaldita.es
+            - name: APP_BASE_URL
+              value: https://pas-dev.fullfact.org
             - name: API_KEYS
               valueFrom:
                 secretKeyRef:
                   name: core-api-keys
                   key: keys
+            - name: NARRATIVES_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: core-api-keys
+                  key: narratives-api-key
         - name: cloud-sql-proxy
           image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.17.1
           args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,20 @@ readme = "README.md"
 requires-python = ">=3.13"
 
 dependencies = [
+    "click>=8.1.0",
     "google-genai>=1.25.0",
+    "httpx>=0.27.0",
     "litestar[opentelemetry,pydantic,standard,structlog]>=2.16.0",
     "psycopg[binary,pool]>=3.2.9",
     "sentence-transformers>=5.0.0",
     "torch>=2.7.1",
 ]
+
+[project.scripts]
+start-narratives = "core.cli:start_narratives"
+
+[tool.setuptools.packages.find]
+include = ["core*"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -121,7 +121,9 @@ name = "core-api"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "click" },
     { name = "google-genai" },
+    { name = "httpx" },
     { name = "litestar", extra = ["opentelemetry", "pydantic", "standard", "structlog"] },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "sentence-transformers" },
@@ -142,7 +144,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.1.0" },
     { name = "google-genai", specifier = ">=1.25.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "litestar", extras = ["opentelemetry", "pydantic", "standard", "structlog"], specifier = ">=2.16.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.9" },
     { name = "sentence-transformers", specifier = ">=5.0.0" },
@@ -1390,7 +1394,7 @@ dependencies = [
     { name = "colorama" },
     { name = "mslex", marker = "sys_platform == 'win32'" },
     { name = "psutil" },
-    { name = "tomli", marker = "python_full_version < '4.0'" },
+    { name = "tomli", marker = "python_full_version < '4'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/44/572261df3db9c6c3332f8618fafeb07a578fd18b06673c73f000f3586749/taskipy-1.14.1.tar.gz", hash = "sha256:410fbcf89692dfd4b9f39c2b49e1750b0a7b81affd0e2d7ea8c35f9d6a4774ed", size = 14475, upload-time = "2024-11-26T16:37:46.155Z" }
 wheels = [


### PR DESCRIPTION
- Implements narrative and topic entities with their migrations. 
- Implements a paginated response (PaginatedJSON) that will be used when hitting general index endpoints from the backend (videos, claims, narratives) - this will allow pagination with total counts in the frontend. 
- Adds endpoints for new entities and also for some already existing entities (GET videos, GET claims, PATCH claim topics, GET narratives (general endpoint, viral and prevalent) 
- Move topics out of the claims metadata
- Adds a couple of new env vars: ’NARRATIVES_API_KEY’ will be used to authenticate against the narratives system. In the deployment.yaml I added the entry referring to the already existing ‘core-api-keys’ secret. The other is NARRATIVES_BASE_ENDPOINT and it’s hardcoded in the deployment.yaml.
- Adds another env called APP_BASE_URL pointing for now to https://pas-dev.fullfact.org/ - The narratives API receives the webhooks where it should return the results on each call, so we need this to generate the full URL to the PATCH claims and POST narratives from the CLI. 
- Adds a new CLI command called start_narratives that quicks off the narratives system with a configurable amount of claims.
- For that CLI command, we’ve added click as a dependency.