### PR TITLE
Frontend linter and model fixes

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -10,7 +10,6 @@ from dotenv import load_dotenv
 from core.app import pool_factory, postgres_url
 from core.videos.claims.repo import ClaimRepository
 
-
 load_dotenv()
 
 
@@ -33,44 +32,48 @@ async def initialize_dashboard(claims):
     narratives_base_endpoint = os.environ.get("NARRATIVES_BASE_ENDPOINT")
     narratives_api_key = os.environ.get("NARRATIVES_API_KEY")
     app_base_url = os.environ.get("APP_BASE_URL")
-    
+
     if not narratives_base_endpoint or not narratives_api_key or not app_base_url:
-        click.echo("Error: NARRATIVES_BASE_ENDPOINT, NARRATIVES_API_KEY, and APP_BASE_URL must be set", err=True)
+        click.echo(
+            "Error: NARRATIVES_BASE_ENDPOINT, NARRATIVES_API_KEY, and APP_BASE_URL must be set",
+            err=True,
+        )
         sys.exit(1)
-    
+
     # Generate the absolute API endpoint URLs with placeholders
     claim_api_url = urljoin(app_base_url, "/api/videos/{video_id}/claims/{claim_id}")
     narratives_api_url = urljoin(app_base_url, "/api/narratives")
-    
+
     # Prepare the request payload
     payload = {
         "claims": [
             {
                 "claim": claim.claim,
                 "id": str(claim.id),
-                "video_id": str(claim.video_id) if claim.video_id else None
+                "video_id": str(claim.video_id) if claim.video_id else None,
             }
             for claim in claims
         ],
         "narratives_api_url": narratives_api_url,
-        "claim_api_url": claim_api_url
+        "claim_api_url": claim_api_url,
     }
-    
+
     # Send POST request to initialize-dashboard endpoint
     url = urljoin(narratives_base_endpoint, "/initialize-dashboard")
-    headers = {
-        "X-API-TOKEN": narratives_api_key,
-        "Content-Type": "application/json"
-    }
-    
+    headers = {"X-API-TOKEN": narratives_api_key, "Content-Type": "application/json"}
+
     async with httpx.AsyncClient() as client:
         try:
-            response = await client.post(url, json=payload, headers=headers, timeout=60.0)
+            response = await client.post(
+                url, json=payload, headers=headers, timeout=60.0
+            )
             response.raise_for_status()
             click.echo(f"Successfully initialized dashboard with {len(claims)} claims")
             return response.json()
         except httpx.HTTPStatusError as e:
-            click.echo(f"Error: HTTP {e.response.status_code} - {e.response.text}", err=True)
+            click.echo(
+                f"Error: HTTP {e.response.status_code} - {e.response.text}", err=True
+            )
             sys.exit(1)
         except Exception as e:
             click.echo(f"Error: {e}", err=True)
@@ -78,25 +81,26 @@ async def initialize_dashboard(claims):
 
 
 @click.command()
-@click.argument('num_claims', type=int, default=400)
+@click.argument("num_claims", type=int, default=400)
 def start_narratives(num_claims):
     """Extract claims from the database and initialize the narratives dashboard.
-    
+
     NUM_CLAIMS: Number of claims to fetch (default: 400)
     """
+
     async def main():
         click.echo(f"Fetching {num_claims} claims from database...")
         claims = await fetch_claims(num_claims)
         click.echo(f"Found {len(claims)} claims")
-        
+
         if not claims:
             click.echo("No claims found in database", err=True)
             return
-        
+
         click.echo("Initializing narratives dashboard...")
-        result = await initialize_dashboard(claims)
+        await initialize_dashboard(claims)
         click.echo("Dashboard initialization complete!")
-    
+
     asyncio.run(main())
 
 

--- a/core/models.py
+++ b/core/models.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class Video(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    title: str
+    description: str
+    platform: str
+    source_url: str
+    destination_path: str
+    uploaded_at: datetime | None
+    views: int | None = None
+    likes: int | None = None
+    comments: int | None = None
+    channel: str | None = None
+    channel_followers: int | None = None
+    scrape_topic: str | None = None
+    scrape_keyword: str | None = None
+    metadata: dict[str, Any] = {}
+
+
+class TranscriptSentence(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    source: str  # Speech-to-text, OCR, etc
+    text: str  # The actual text of the sentence
+    start_time_s: float  # Start time in seconds
+    metadata: dict[str, Any] = {}
+
+
+class Transcript(BaseModel):
+    video_id: UUID | None
+    sentences: list[TranscriptSentence]
+
+
+class Claim(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    video_id: UUID | None = None  # Reference to the video
+    claim: str  # The claim made in the video
+    start_time_s: float  # When in the video the claim starts
+    metadata: dict[str, Any] = {}  # Additional metadata about the claim
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class Topic(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    topic: str
+    metadata: dict[str, Any] = {}
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class Narrative(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    title: str
+    description: str
+    claims: list[Claim] = []
+    topics: list[Topic] = []
+    videos: list[Video] = []
+    metadata: dict[str, Any] = {}
+    created_at: datetime | None = None
+    updated_at: datetime | None = None

--- a/core/narratives/controller.py
+++ b/core/narratives/controller.py
@@ -6,10 +6,11 @@ from litestar.di import Provide
 from litestar.exceptions import NotFoundException
 
 from core.errors import ConflictError
+from core.models import Narrative
+from core.narratives.models import NarrativeInput
+from core.narratives.service import NarrativeService
 from core.response import JSON, PaginatedJSON
 from core.uow import ConnectionFactory
-from core.narratives.models import Narrative, NarrativeInput
-from core.narratives.service import NarrativeService
 
 
 async def narrative_service(
@@ -61,13 +62,12 @@ class NarrativeController(Controller):
         limit: int = 100,
         offset: int = 0,
     ) -> PaginatedJSON[list[Narrative]]:
-        narratives, total = await narrative_service.get_all_narratives(limit=limit, offset=offset)
+        narratives, total = await narrative_service.get_all_narratives(
+            limit=limit, offset=offset
+        )
         page = (offset // limit) + 1 if limit > 0 else 1
         return PaginatedJSON(
-            data=narratives,
-            total=total,
-            page=page,
-            size=len(narratives)
+            data=narratives, total=total, page=page, size=len(narratives)
         )
 
     @get(
@@ -91,7 +91,9 @@ class NarrativeController(Controller):
         hours: int = 24,
     ) -> JSON[list[Narrative]]:
         return JSON(
-            await narrative_service.get_viral_narratives(limit=limit, offset=offset, hours=hours)
+            await narrative_service.get_viral_narratives(
+                limit=limit, offset=offset, hours=hours
+            )
         )
 
     @get(
@@ -106,7 +108,9 @@ class NarrativeController(Controller):
         hours: int = 24,
     ) -> JSON[list[Narrative]]:
         return JSON(
-            await narrative_service.get_prevalent_narratives(limit=limit, offset=offset, hours=hours)
+            await narrative_service.get_prevalent_narratives(
+                limit=limit, offset=offset, hours=hours
+            )
         )
 
     @patch(

--- a/core/narratives/models.py
+++ b/core/narratives/models.py
@@ -1,23 +1,7 @@
-from datetime import datetime
 from typing import Any
-from uuid import UUID, uuid4
+from uuid import UUID
 
-from pydantic import BaseModel, Field
-
-from core.topics.models import Topic
-from core.videos.claims.models import Claim
-
-
-class Narrative(BaseModel):
-    id: UUID = Field(default_factory=uuid4)
-    title: str
-    description: str
-    claims: list[Claim] = []
-    topics: list[Topic] = []
-    videos: list[Any] = []
-    metadata: dict[str, Any] = {}
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
+from pydantic import BaseModel
 
 
 class NarrativeInput(BaseModel):

--- a/core/narratives/repo.py
+++ b/core/narratives/repo.py
@@ -158,7 +158,7 @@ class NarrativeRepository:
         metadata: dict[str, Any] | None = None,
     ) -> Narrative | None:
         updates = []
-        params = {"narrative_id": narrative_id}
+        params: dict[str, Any] = {"narrative_id": narrative_id}
 
         if title is not None:
             updates.append("title = %(title)s")
@@ -316,6 +316,8 @@ class NarrativeRepository:
             {"claim_ids": claim_ids},
         )
         row = await self._session.fetchone()
+        if not row:
+            return False
         return row["count"] == len(claim_ids)
 
     async def get_narratives_by_topic(

--- a/core/narratives/service.py
+++ b/core/narratives/service.py
@@ -1,9 +1,10 @@
 from typing import Any, AsyncContextManager
 from uuid import UUID
 
-from core.uow import ConnectionFactory, uow
-from core.narratives.models import Narrative, NarrativeInput
+from core.models import Narrative
+from core.narratives.models import NarrativeInput
 from core.narratives.repo import NarrativeRepository
+from core.uow import ConnectionFactory, uow
 
 
 class NarrativeService:
@@ -13,13 +14,11 @@ class NarrativeService:
     def repo(self) -> AsyncContextManager[NarrativeRepository]:
         return uow(NarrativeRepository, self._connection_factory)
 
-    async def create_narrative(
-        self, narrative: NarrativeInput
-    ) -> Narrative:
+    async def create_narrative(self, narrative: NarrativeInput) -> Narrative:
         async with self.repo() as repo:
             if not await repo.claims_exist(narrative.claim_ids):
                 raise ValueError("one or more claims not found")
-            
+
             return await repo.create_narrative(
                 title=narrative.title,
                 description=narrative.description,
@@ -74,21 +73,27 @@ class NarrativeService:
             if not updated:
                 raise ValueError("narrative not found")
             return updated.metadata
-    
+
     async def get_narratives_by_topic(
         self, topic_id: UUID, limit: int = 100, offset: int = 0
     ) -> tuple[list[Narrative], int]:
         async with self.repo() as repo:
-            return await repo.get_narratives_by_topic(topic_id, limit=limit, offset=offset)
-    
+            return await repo.get_narratives_by_topic(
+                topic_id, limit=limit, offset=offset
+            )
+
     async def get_viral_narratives(
         self, limit: int = 100, offset: int = 0, hours: int = 24
     ) -> list[Narrative]:
         async with self.repo() as repo:
-            return await repo.get_viral_narratives(limit=limit, offset=offset, hours=hours)
-    
+            return await repo.get_viral_narratives(
+                limit=limit, offset=offset, hours=hours
+            )
+
     async def get_prevalent_narratives(
         self, limit: int = 100, offset: int = 0, hours: int = 24
     ) -> list[Narrative]:
         async with self.repo() as repo:
-            return await repo.get_prevalent_narratives(limit=limit, offset=offset, hours=hours)
+            return await repo.get_prevalent_narratives(
+                limit=limit, offset=offset, hours=hours
+            )

--- a/core/topics/controller.py
+++ b/core/topics/controller.py
@@ -7,13 +7,13 @@ from litestar.dto import DTOData
 from litestar.exceptions import NotFoundException
 
 from core.errors import ConflictError
-from core.response import JSON, PaginatedJSON
-from core.uow import ConnectionFactory
-from core.narratives.models import Narrative
+from core.models import Claim, Narrative, Topic
 from core.narratives.service import NarrativeService
-from core.topics.models import Topic, TopicDTO, TopicWithStats
+from core.response import JSON, PaginatedJSON
+from core.topics.models import TopicDTO, TopicWithStats
 from core.topics.service import TopicService
-from core.videos.claims.models import Claim
+from core.uow import ConnectionFactory
+from core.videos.claims.models import EnrichedClaim
 from core.videos.claims.service import ClaimsService
 
 
@@ -93,9 +93,7 @@ class TopicController(Controller):
         limit: int = 100,
         offset: int = 0,
     ) -> JSON[list[Topic]]:
-        return JSON(
-            await topic_service.get_all_topics(limit=limit, offset=offset)
-        )
+        return JSON(await topic_service.get_all_topics(limit=limit, offset=offset))
 
     @get(
         path="/search",
@@ -107,7 +105,7 @@ class TopicController(Controller):
         query: str,
     ) -> JSON[list[Topic]]:
         return JSON(await topic_service.search_topics(query))
-    
+
     @get(
         path="/stats",
         summary="Get all topics with narrative and claim counts",
@@ -178,7 +176,7 @@ class TopicController(Controller):
         topic_id: UUID,
     ) -> None:
         await topic_service.delete_topic(topic_id)
-    
+
     @get(
         path="/{topic_id:uuid}/narratives",
         summary="Get all narratives for a specific topic",
@@ -200,7 +198,7 @@ class TopicController(Controller):
             page=page,
             size=limit,
         )
-    
+
     @get(
         path="/{topic_id:uuid}/claims",
         summary="Get all claims for a specific topic",
@@ -211,7 +209,7 @@ class TopicController(Controller):
         topic_id: UUID,
         limit: int = 100,
         offset: int = 0,
-    ) -> PaginatedJSON[list[Claim]]:
+    ) -> PaginatedJSON[list[EnrichedClaim]]:
         claims, total = await claims_service.get_claims_by_topic(
             topic_id, limit=limit, offset=offset
         )

--- a/core/topics/controller.py
+++ b/core/topics/controller.py
@@ -7,7 +7,7 @@ from litestar.dto import DTOData
 from litestar.exceptions import NotFoundException
 
 from core.errors import ConflictError
-from core.models import Claim, Narrative, Topic
+from core.models import Narrative, Topic
 from core.narratives.service import NarrativeService
 from core.response import JSON, PaginatedJSON
 from core.topics.models import TopicDTO, TopicWithStats

--- a/core/topics/models.py
+++ b/core/topics/models.py
@@ -1,18 +1,7 @@
-from datetime import datetime
-from typing import Any
-from uuid import UUID, uuid4
-
 from litestar.dto import DTOConfig
 from litestar.plugins.pydantic import PydanticDTO
-from pydantic import BaseModel, Field
 
-
-class Topic(BaseModel):
-    id: UUID = Field(default_factory=uuid4)
-    topic: str
-    metadata: dict[str, Any] = {}
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
+from core.models import Topic
 
 
 class TopicWithStats(Topic):

--- a/core/topics/repo.py
+++ b/core/topics/repo.py
@@ -6,16 +6,15 @@ from psycopg.rows import DictRow
 from psycopg.types.json import Jsonb
 
 from core.errors import ConflictError
-from core.topics.models import Topic, TopicWithStats
+from core.models import Topic
+from core.topics.models import TopicWithStats
 
 
 class TopicRepository:
     def __init__(self, session: psycopg.AsyncCursor[DictRow]) -> None:
         self._session = session
 
-    async def create_topic(
-        self, topic: str, metadata: dict[str, Any]
-    ) -> Topic:
+    async def create_topic(self, topic: str, metadata: dict[str, Any]) -> Topic:
         try:
             await self._session.execute(
                 """
@@ -63,9 +62,7 @@ class TopicRepository:
             return None
         return Topic(**row)
 
-    async def get_all_topics(
-        self, limit: int = 100, offset: int = 0
-    ) -> list[Topic]:
+    async def get_all_topics(self, limit: int = 100, offset: int = 0) -> list[Topic]:
         await self._session.execute(
             """
             SELECT * FROM topics
@@ -109,7 +106,7 @@ class TopicRepository:
             return await self.get_topic(topic_id)
 
         updates.append("updated_at = now()")
-        
+
         try:
             await self._session.execute(
                 f"""
@@ -148,7 +145,7 @@ class TopicRepository:
             {"narrative_id": narrative_id},
         )
         return [Topic(**row) for row in await self._session.fetchall()]
-    
+
     async def get_all_topics_with_stats(
         self, limit: int = 100, offset: int = 0
     ) -> tuple[list[TopicWithStats], int]:
@@ -156,11 +153,11 @@ class TopicRepository:
         await self._session.execute("SELECT COUNT(*) FROM topics")
         total_row = await self._session.fetchone()
         total = total_row["count"] if total_row else 0
-        
+
         # Get topics with stats
         await self._session.execute(
             """
-            SELECT 
+            SELECT
                 t.*,
                 COUNT(DISTINCT nt.narrative_id) as narrative_count,
                 COUNT(DISTINCT ct.claim_id) as claim_count

--- a/core/topics/repo.py
+++ b/core/topics/repo.py
@@ -92,7 +92,7 @@ class TopicRepository:
         metadata: dict[str, Any] | None = None,
     ) -> Topic | None:
         updates = []
-        params = {"topic_id": topic_id}
+        params: dict[str, Any] = {"topic_id": topic_id}
 
         if topic is not None:
             updates.append("topic = %(topic)s")

--- a/core/topics/service.py
+++ b/core/topics/service.py
@@ -3,9 +3,10 @@ from uuid import UUID
 
 from litestar.dto import DTOData
 
-from core.uow import ConnectionFactory, uow
-from core.topics.models import Topic, TopicWithStats
+from core.models import Topic
+from core.topics.models import TopicWithStats
 from core.topics.repo import TopicRepository
+from core.uow import ConnectionFactory, uow
 
 
 class TopicService:
@@ -15,12 +16,10 @@ class TopicService:
     def repo(self) -> AsyncContextManager[TopicRepository]:
         return uow(TopicRepository, self._connection_factory)
 
-    async def create_topic(
-        self, topic: Topic | DTOData[Topic]
-    ) -> Topic:
+    async def create_topic(self, topic: Topic | DTOData[Topic]) -> Topic:
         if isinstance(topic, DTOData):
             topic = topic.create_instance()
-        
+
         async with self.repo() as repo:
             return await repo.create_topic(
                 topic=topic.topic,
@@ -35,9 +34,7 @@ class TopicService:
         async with self.repo() as repo:
             return await repo.get_topic_by_name(topic)
 
-    async def get_all_topics(
-        self, limit: int = 100, offset: int = 0
-    ) -> list[Topic]:
+    async def get_all_topics(self, limit: int = 100, offset: int = 0) -> list[Topic]:
         async with self.repo() as repo:
             return await repo.get_all_topics(limit=limit, offset=offset)
 
@@ -52,7 +49,7 @@ class TopicService:
     ) -> Topic | None:
         if isinstance(data, DTOData):
             data = data.as_builtins()
-        
+
         async with self.repo() as repo:
             return await repo.update_topic(
                 topic_id=topic_id,
@@ -79,7 +76,7 @@ class TopicService:
     async def get_topics_by_narrative(self, narrative_id: UUID) -> list[Topic]:
         async with self.repo() as repo:
             return await repo.get_topics_by_narrative(narrative_id)
-    
+
     async def get_all_topics_with_stats(
         self, limit: int = 100, offset: int = 0
     ) -> tuple[list[TopicWithStats], int]:

--- a/core/topics/service.py
+++ b/core/topics/service.py
@@ -53,8 +53,8 @@ class TopicService:
         async with self.repo() as repo:
             return await repo.update_topic(
                 topic_id=topic_id,
-                topic=data.get("topic"),
-                metadata=data.get("metadata"),
+                topic=data.get("topic"),  # type: ignore
+                metadata=data.get("metadata"),  # type: ignore
             )
 
     async def delete_topic(self, topic_id: UUID) -> None:

--- a/core/videos/claims/controller.py
+++ b/core/videos/claims/controller.py
@@ -2,17 +2,18 @@ from typing import Any
 from uuid import UUID
 
 from litestar import Controller, delete, get, patch, post
-from litestar.params import Parameter
 from litestar.di import Provide
 from litestar.dto import DTOData
 from litestar.exceptions import NotFoundException
+from litestar.params import Parameter
 
 from core.errors import ConflictError
+from core.models import Claim
 from core.response import JSON, PaginatedJSON
 from core.uow import ConnectionFactory
 from core.videos.claims.models import (
-    Claim,
     ClaimUpdate,
+    EnrichedClaim,
     VideoClaims,
     VideoClaimsDTO,
 )
@@ -91,7 +92,7 @@ class ClaimController(Controller):
         claim_id: UUID,
     ) -> None:
         await claims_service.delete_claim(claim_id)
-    
+
     @patch(
         path="/{claim_id:uuid}",
         summary="Update claim associations (topics and entities)",
@@ -107,7 +108,7 @@ class ClaimController(Controller):
             updated_claim = await claims_service.update_claim_associations(
                 claim_id=claim_id,
                 topic_ids=data.topics,
-                entity_ids=data.entities if data.entities else None
+                entity_ids=data.entities if data.entities else None,
             )
             return JSON(updated_claim)
         except ValueError:
@@ -132,7 +133,7 @@ class RootClaimController(Controller):
         topic_id: UUID | None = Parameter(None, query="topic_id"),
         limit: int = Parameter(100, query="limit", gt=0, le=1000),
         offset: int = Parameter(0, query="offset", ge=0),
-    ) -> PaginatedJSON[list[Claim]]:
+    ) -> PaginatedJSON[list[EnrichedClaim]]:
         claims, total = await claims_service.get_all_claims(
             limit=limit, offset=offset, topic_id=topic_id
         )

--- a/core/videos/claims/models.py
+++ b/core/videos/claims/models.py
@@ -1,26 +1,16 @@
-from datetime import datetime
-from typing import Any
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from litestar.dto import DTOConfig
 from litestar.plugins.pydantic import PydanticDTO
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
-from core.topics.models import Topic
+from core.models import Claim, Narrative, Topic, Video
 
 
-class Claim(BaseModel):
-    id: UUID = Field(default_factory=uuid4)
-    video_id: UUID | None = None  # Reference to the video
-    claim: str  # The claim made in the video
-    start_time_s: float  # When in the video the claim starts
-    embedding: list[float] | None = None
-    metadata: dict[str, Any] = Field(default_factory=dict)  # Additional metadata about the claim
-    topics: list[Topic] = Field(default_factory=list)  # Associated topics
-    video: Any | None = None  # Video information
-    narratives: list[Any] = Field(default_factory=list)  # Associated narratives
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
+class EnrichedClaim(Claim):
+    topics: list[Topic] = []  # Associated topics
+    video: Video | None = None  # Video information
+    narratives: list[Narrative] = []  # Associated narratives
 
 
 class VideoClaims(BaseModel):
@@ -32,11 +22,12 @@ class VideoClaimsDTO(PydanticDTO[VideoClaims]):
     config = DTOConfig(
         exclude={
             "video_id",
-            "embedding",
+            "claims.*.created_at",
+            "claims.*.updated_at",
         },
     )
 
 
 class ClaimUpdate(BaseModel):
-    entities: list[UUID] = Field(default_factory=list)  # Future entity IDs
-    topics: list[UUID] = Field(default_factory=list)  # Topic IDs to associate
+    entities: list[UUID] = []  # Future entity IDs
+    topics: list[UUID] = []  # Topic IDs to associate

--- a/core/videos/claims/repo.py
+++ b/core/videos/claims/repo.py
@@ -196,7 +196,7 @@ class ClaimRepository:
     ) -> tuple[list[EnrichedClaim], int]:
         # Build the query conditionally
         where_clause = ""
-        params = {"limit": limit, "offset": offset}
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
 
         if topic_id:
             where_clause = "WHERE ct.topic_id = %(topic_id)s"

--- a/core/videos/claims/repo.py
+++ b/core/videos/claims/repo.py
@@ -7,8 +7,8 @@ from psycopg.types.json import Jsonb
 
 from core.analysis import embedding
 from core.errors import ConflictError
-from core.videos.claims.models import Claim
-from core.topics.models import Topic
+from core.models import Claim, Narrative, Topic, Video
+from core.videos.claims.models import EnrichedClaim
 
 
 class ClaimRepository:
@@ -24,7 +24,7 @@ class ClaimRepository:
                 ) VALUES (
                     %(id)s, %(video_id)s, %(claim)s, %(start_time_s)s, %(metadata)s, %(embedding)s
                 )
-                RETURNING *, embedding::real[]
+                RETURNING *
                 """,
                 [
                     x.model_dump()
@@ -45,7 +45,7 @@ class ClaimRepository:
             row = await self._session.fetchone()
             if not row:
                 break
-            added_claims.append(self._create_claim_from_row(row, None, None, None, include_embedding=False))
+            added_claims.append(Claim(**row))
             if not self._session.nextset():
                 break
 
@@ -54,14 +54,14 @@ class ClaimRepository:
     async def get_claims_for_video(self, video_id: UUID) -> list[Claim]:
         await self._session.execute(
             """
-            SELECT *, embedding::real[]
+            SELECT *
             FROM video_claims
             WHERE video_id = %(video_id)s
             ORDER BY start_time_s ASC
             """,
             {"video_id": video_id},
         )
-        return [self._create_claim_from_row(row, None, None, None, include_embedding=False) for row in await self._session.fetchall()]
+        return [Claim(**row) for row in await self._session.fetchall()]
 
     async def delete_video_claims(self, video_id: UUID) -> None:
         await self._session.execute(
@@ -82,7 +82,7 @@ class ClaimRepository:
                 metadata = metadata || %(metadata)s,
                 updated_at = now()
             WHERE id = %(claim_id)s
-            RETURNING *, embedding::real[]
+            RETURNING *
             """,
             {"claim_id": claim_id, "metadata": Jsonb(metadata)},
         )
@@ -107,14 +107,14 @@ class ClaimRepository:
             {"video_id": video_id},
         )
         return (await self._session.fetchone()) is not None
-    
+
     async def get_claims_by_topic(
         self, topic_id: UUID, limit: int = 100, offset: int = 0
-    ) -> tuple[list[Claim], int]:
+    ) -> tuple[list[EnrichedClaim], int]:
         # Get total count
         await self._session.execute(
             """
-            SELECT COUNT(DISTINCT c.id) 
+            SELECT COUNT(DISTINCT c.id)
             FROM video_claims c
             JOIN claim_topics ct ON c.id = ct.claim_id
             WHERE ct.topic_id = %(topic_id)s
@@ -123,7 +123,7 @@ class ClaimRepository:
         )
         total_row = await self._session.fetchone()
         total = total_row["count"] if total_row else 0
-        
+
         # Get claims
         await self._session.execute(
             """
@@ -136,16 +136,22 @@ class ClaimRepository:
             """,
             {"topic_id": topic_id, "limit": limit, "offset": offset},
         )
-        
+
         claims = []
         for row in await self._session.fetchall():
             topics = await self._get_claim_topics(row["id"])
-            video = await self._get_video_info(row["video_id"]) if row.get("video_id") else None
+            video = (
+                await self._get_video_info(row["video_id"])
+                if row.get("video_id")
+                else None
+            )
             narratives = await self._get_claim_narratives(row["id"])
-            claims.append(self._create_claim_from_row(row, topics, video, narratives, include_embedding=False))
-        
+            claims.append(
+                EnrichedClaim(topics=topics, video=video, narratives=narratives, **row)
+            )
+
         return claims, total
-    
+
     async def _get_claim_topics(self, claim_id: UUID) -> list[Topic]:
         await self._session.execute(
             """
@@ -158,8 +164,8 @@ class ClaimRepository:
             {"claim_id": claim_id},
         )
         return [Topic(**row) for row in await self._session.fetchall()]
-    
-    async def _get_claim_narratives(self, claim_id: UUID) -> list[dict]:
+
+    async def _get_claim_narratives(self, claim_id: UUID) -> list[Narrative]:
         await self._session.execute(
             """
             SELECT n.id, n.title, n.description, n.metadata, n.created_at, n.updated_at
@@ -170,12 +176,12 @@ class ClaimRepository:
             """,
             {"claim_id": claim_id},
         )
-        return [dict(row) for row in await self._session.fetchall()]
-    
-    async def _get_video_info(self, video_id: UUID) -> dict | None:
+        return [Narrative(**row) for row in await self._session.fetchall()]
+
+    async def _get_video_info(self, video_id: UUID) -> Video | None:
         await self._session.execute(
             """
-            SELECT id, title, description, platform, source_url, channel, 
+            SELECT id, title, description, platform, source_url, channel,
                    uploaded_at, views, likes, comments, metadata
             FROM videos
             WHERE id = %(video_id)s
@@ -183,51 +189,22 @@ class ClaimRepository:
             {"video_id": video_id},
         )
         row = await self._session.fetchone()
-        return dict(row) if row else None
-    
-    def _create_claim_from_row(self, row: DictRow, topics: list[Topic] | None = None, 
-                              video: dict | None = None, narratives: list[dict] | None = None,
-                              include_embedding: bool = True) -> Claim:
-        """Helper method to create a Claim from a database row, handling embedding field properly."""
-        claim_data = dict(row)
-        
-        # Exclude embedding if not needed
-        if not include_embedding:
-            claim_data.pop("embedding", None)
-        else:
-            # Handle embedding field - it might come as a string from the database
-            if claim_data.get("embedding") and isinstance(claim_data["embedding"], str):
-                import json
-                try:
-                    claim_data["embedding"] = json.loads(claim_data["embedding"])
-                except:
-                    claim_data["embedding"] = None
-        
-        if topics is not None:
-            claim_data["topics"] = topics
-        
-        if video is not None:
-            claim_data["video"] = video
-            
-        if narratives is not None:
-            claim_data["narratives"] = narratives
-        
-        return Claim(**claim_data)
-    
+        return Video(**row) if row else None
+
     async def get_all_claims(
         self, limit: int = 100, offset: int = 0, topic_id: UUID | None = None
-    ) -> tuple[list[Claim], int]:
+    ) -> tuple[list[EnrichedClaim], int]:
         # Build the query conditionally
         where_clause = ""
         params = {"limit": limit, "offset": offset}
-        
+
         if topic_id:
             where_clause = "WHERE ct.topic_id = %(topic_id)s"
             params["topic_id"] = topic_id
-        
+
         # Get total count
         count_query = f"""
-            SELECT COUNT(DISTINCT c.id) 
+            SELECT COUNT(DISTINCT c.id)
             FROM video_claims c
             {"JOIN claim_topics ct ON c.id = ct.claim_id" if topic_id else ""}
             {where_clause}
@@ -235,7 +212,7 @@ class ClaimRepository:
         await self._session.execute(count_query, params)
         total_row = await self._session.fetchone()
         total = total_row["count"] if total_row else 0
-        
+
         # Get claims
         claims_query = f"""
             SELECT DISTINCT c.*
@@ -246,16 +223,22 @@ class ClaimRepository:
             LIMIT %(limit)s OFFSET %(offset)s
         """
         await self._session.execute(claims_query, params)
-        
+
         claims = []
         for row in await self._session.fetchall():
             topics = await self._get_claim_topics(row["id"])
-            video = await self._get_video_info(row["video_id"]) if row.get("video_id") else None
+            video = (
+                await self._get_video_info(row["video_id"])
+                if row.get("video_id")
+                else None
+            )
             narratives = await self._get_claim_narratives(row["id"])
-            claims.append(self._create_claim_from_row(row, topics, video, narratives, include_embedding=False))
-        
+            claims.append(
+                EnrichedClaim(topics=topics, video=video, narratives=narratives, **row)
+            )
+
         return claims, total
-    
+
     async def associate_topics_with_claim(
         self, claim_id: UUID, topic_ids: list[UUID]
     ) -> None:
@@ -267,7 +250,7 @@ class ClaimRepository:
             """,
             {"claim_id": claim_id},
         )
-        
+
         # Then add new associations
         if topic_ids:
             await self._session.executemany(
@@ -280,8 +263,8 @@ class ClaimRepository:
                     for topic_id in topic_ids
                 ],
             )
-    
-    async def get_claim_by_id(self, claim_id: UUID) -> Claim | None:
+
+    async def get_claim_by_id(self, claim_id: UUID) -> EnrichedClaim | None:
         await self._session.execute(
             """
             SELECT * FROM video_claims
@@ -292,8 +275,10 @@ class ClaimRepository:
         row = await self._session.fetchone()
         if not row:
             return None
-        
+
         topics = await self._get_claim_topics(claim_id)
-        video = await self._get_video_info(row["video_id"]) if row.get("video_id") else None
+        video = (
+            await self._get_video_info(row["video_id"]) if row.get("video_id") else None
+        )
         narratives = await self._get_claim_narratives(claim_id)
-        return self._create_claim_from_row(row, topics, video, narratives, include_embedding=False)
+        return EnrichedClaim(topics=topics, video=video, narratives=narratives, **row)

--- a/core/videos/claims/service.py
+++ b/core/videos/claims/service.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from litestar.dto import DTOData
 
 from core.uow import ConnectionFactory, uow
-from core.videos.claims.models import Claim, VideoClaims
+from core.videos.claims.models import EnrichedClaim, VideoClaims
 from core.videos.claims.repo import ClaimRepository
 
 
@@ -44,40 +44,45 @@ class ClaimsService:
     async def delete_claim(self, claim_id: UUID) -> None:
         async with self.repo() as repo:
             return await repo.delete_claim(claim_id)
-    
+
     async def get_claims_by_topic(
         self, topic_id: UUID, limit: int = 100, offset: int = 0
-    ) -> tuple[list[Claim], int]:
+    ) -> tuple[list[EnrichedClaim], int]:
         async with self.repo() as repo:
             return await repo.get_claims_by_topic(topic_id, limit=limit, offset=offset)
-    
+
     async def get_all_claims(
         self, limit: int = 100, offset: int = 0, topic_id: UUID | None = None
-    ) -> tuple[list[Claim], int]:
+    ) -> tuple[list[EnrichedClaim], int]:
         async with self.repo() as repo:
-            return await repo.get_all_claims(limit=limit, offset=offset, topic_id=topic_id)
-    
+            return await repo.get_all_claims(
+                limit=limit, offset=offset, topic_id=topic_id
+            )
+
     async def associate_topics_with_claim(
         self, claim_id: UUID, topic_ids: list[UUID]
     ) -> None:
         async with self.repo() as repo:
             await repo.associate_topics_with_claim(claim_id, topic_ids)
-    
+
     async def update_claim_associations(
-        self, claim_id: UUID, topic_ids: list[UUID], entity_ids: list[UUID] | None = None
-    ) -> Claim:
+        self,
+        claim_id: UUID,
+        topic_ids: list[UUID],
+        entity_ids: list[UUID] | None = None,
+    ) -> EnrichedClaim:
         async with self.repo() as repo:
             # Check if claim exists
             claim = await repo.get_claim_by_id(claim_id)
             if not claim:
                 raise ValueError(f"Claim with ID {claim_id} not found")
-            
+
             # Update topic associations
             await repo.associate_topics_with_claim(claim_id, topic_ids)
-            
+
             # TODO: When entities are implemented, update entity associations here
             # if entity_ids is not None:
             #     await repo.associate_entities_with_claim(claim_id, entity_ids)
-            
+
             # Return updated claim with new associations
             return await repo.get_claim_by_id(claim_id)

--- a/core/videos/claims/service.py
+++ b/core/videos/claims/service.py
@@ -85,4 +85,7 @@ class ClaimsService:
             #     await repo.associate_entities_with_claim(claim_id, entity_ids)
 
             # Return updated claim with new associations
-            return await repo.get_claim_by_id(claim_id)
+            claim = await repo.get_claim_by_id(claim_id)
+            if not claim:
+                raise ValueError(f"Claim with ID {claim_id} not found")
+            return claim

--- a/core/videos/models.py
+++ b/core/videos/models.py
@@ -1,65 +1,19 @@
-from datetime import datetime
 from typing import Annotated, Any
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import annotated_types
 from litestar.dto import DTOConfig
 from litestar.plugins.pydantic import PydanticDTO
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
+from core.models import Narrative, Transcript, Video
 from core.videos.claims.models import VideoClaims
-from core.videos.transcripts.models import Transcript
 
 
-class Video(BaseModel):
-    id: UUID = Field(default_factory=uuid4)
-    title: str
-    description: str
-    platform: str
-    source_url: str
-    destination_path: str
-    uploaded_at: datetime | None
-    views: int | None = None
-    likes: int | None = None
-    comments: int | None = None
-    channel: str | None = None
-    channel_followers: int | None = None
-    scrape_topic: str | None = None
-    scrape_keyword: str | None = None
-    embedding: list[float] | None = None
-    metadata: dict[str, Any] = {}
-
-
-class VideoResponse(BaseModel):
-    """Response model for videos without embeddings"""
-    id: UUID
-    title: str
-    description: str
-    platform: str
-    source_url: str
-    destination_path: str
-    uploaded_at: datetime | None
-    views: int | None = None
-    likes: int | None = None
-    comments: int | None = None
-    channel: str | None = None
-    channel_followers: int | None = None
-    scrape_topic: str | None = None
-    scrape_keyword: str | None = None
-    metadata: dict[str, Any] = {}
-
-
-class AnalysedVideo(VideoResponse):
+class AnalysedVideo(Video):
     transcript: Transcript | None = None
     claims: VideoClaims | None = None
-    narratives: list[Any] = Field(default_factory=list)
-
-
-class AnalysedVideoWithEmbedding(Video):
-    """Response model for individual video with embeddings included"""
-    transcript: Transcript | None = None
-    claims: VideoClaims | None = None
-    narratives: list[Any] = Field(default_factory=list)
+    narratives: list[Narrative] = []
 
 
 class VideoPatch(PydanticDTO[Video]):

--- a/core/videos/models.py
+++ b/core/videos/models.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any
+from typing import Annotated
 from uuid import UUID
 
 import annotated_types

--- a/core/videos/repo.py
+++ b/core/videos/repo.py
@@ -7,7 +7,8 @@ from psycopg.types.json import Jsonb
 
 from core.analysis import embedding
 from core.errors import ConflictError
-from core.videos.models import Video, VideoFilters
+from core.models import Video
+from core.videos.models import VideoFilters
 
 
 class VideoRepository:
@@ -17,7 +18,7 @@ class VideoRepository:
     async def get_video_by_id(self, video_id: UUID) -> Video | None:
         await self._session.execute(
             """
-            SELECT *, embedding::real[] FROM videos WHERE id = %(video_id)s
+            SELECT * FROM videos WHERE id = %(video_id)s
             """,
             {"video_id": video_id},
         )
@@ -67,7 +68,7 @@ class VideoRepository:
                     %(metadata)s,
                     %(embedding)s
                 )
-                RETURNING *, embedding::real[]
+                RETURNING *
                 """,
                 {
                     **video.model_dump(),
@@ -95,7 +96,7 @@ class VideoRepository:
                 channel_followers = %(channel_followers)s,
                 metadata = metadata || %(metadata)s
             WHERE id = %(id)s
-            RETURNING *, embedding::real[]
+            RETURNING *
             """,
             video.model_dump() | {"metadata": Jsonb(video.metadata)},
         )
@@ -155,7 +156,6 @@ class VideoRepository:
                 v.channel_followers,
                 v.scrape_topic,
                 v.scrape_keyword,
-                v.embedding::real[],
                 v.metadata,
                 v.updated_at,
                 v.created_at
@@ -171,43 +171,47 @@ class VideoRepository:
         return [Video(**row) for row in await self._session.fetchall()]
 
     async def get_videos_paginated(
-        self, limit: int, offset: int, platform: list[str] | None = None, channel: list[str] | None = None
+        self,
+        limit: int,
+        offset: int,
+        platform: list[str] | None = None,
+        channel: list[str] | None = None,
     ) -> tuple[list[Video], int]:
         wheres = [sql.SQL("1=1")]
         params = {"limit": limit, "offset": offset}
-        
+
         if platform:
             wheres.append(sql.SQL("platform = ANY(%(platform)s)"))
             params["platform"] = platform
-        
+
         if channel:
             wheres.append(sql.SQL("channel = ANY(%(channel)s)"))
             params["channel"] = channel
-        
+
         where_clause = sql.Composed(wheres).join(" AND ")
-        
+
         # Get total count
         count_query = sql.SQL("""
             SELECT COUNT(*) FROM videos
             WHERE {wheres}
         """).format(wheres=where_clause)
-        
+
         await self._session.execute(count_query, params)
         total = (await self._session.fetchone())["count"]
-        
+
         # Get paginated results
         data_query = sql.SQL("""
-            SELECT *, embedding::real[] FROM videos
+            SELECT * FROM videos
             WHERE {wheres}
             ORDER BY created_at DESC
             LIMIT %(limit)s OFFSET %(offset)s
         """).format(wheres=where_clause)
-        
+
         await self._session.execute(data_query, params)
         videos = [Video(**row) for row in await self._session.fetchall()]
-        
+
         return videos, total
-    
+
     async def get_narratives_for_video(self, video_id: UUID) -> list[dict]:
         """Get all narratives associated with a video through its claims"""
         await self._session.execute(
@@ -218,7 +222,7 @@ class VideoRepository:
 				JOIN video_claims c ON cn.claim_id = c.id
 				WHERE c.video_id = %(video_id)s AND cn.narrative_id = n.id
 			)
-			ORDER BY n.created_at DESC 
+			ORDER BY n.created_at DESC
             """,
             {"video_id": video_id},
         )

--- a/core/videos/service.py
+++ b/core/videos/service.py
@@ -3,8 +3,9 @@ from uuid import UUID
 
 from litestar.dto import DTOData
 
+from core.models import Video
 from core.uow import ConnectionFactory, uow
-from core.videos.models import Video, VideoFilters
+from core.videos.models import VideoFilters
 from core.videos.repo import VideoRepository
 
 
@@ -40,11 +41,15 @@ class VideoService:
             return await repo.delete_video(video_id)
 
     async def get_videos_paginated(
-        self, limit: int, offset: int, platform: list[str] | None = None, channel: list[str] | None = None
+        self,
+        limit: int,
+        offset: int,
+        platform: list[str] | None = None,
+        channel: list[str] | None = None,
     ) -> tuple[list[Video], int]:
         async with self.repo() as repo:
             return await repo.get_videos_paginated(limit, offset, platform, channel)
-    
+
     async def get_narratives_for_video(self, video_id: UUID) -> list[dict]:
         async with self.repo() as repo:
             return await repo.get_narratives_for_video(video_id)

--- a/core/videos/service.py
+++ b/core/videos/service.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from litestar.dto import DTOData
 
-from core.models import Video
+from core.models import Narrative, Video
 from core.uow import ConnectionFactory, uow
 from core.videos.models import VideoFilters
 from core.videos.repo import VideoRepository
@@ -50,6 +50,6 @@ class VideoService:
         async with self.repo() as repo:
             return await repo.get_videos_paginated(limit, offset, platform, channel)
 
-    async def get_narratives_for_video(self, video_id: UUID) -> list[dict]:
+    async def get_narratives_for_video(self, video_id: UUID) -> list[Narrative]:
         async with self.repo() as repo:
             return await repo.get_narratives_for_video(video_id)

--- a/core/videos/transcripts/controller.py
+++ b/core/videos/transcripts/controller.py
@@ -7,12 +7,10 @@ from litestar.dto import DTOData
 from litestar.exceptions import NotFoundException
 
 from core.errors import ConflictError
+from core.models import Transcript
 from core.response import JSON
 from core.uow import ConnectionFactory
-from core.videos.transcripts.models import (
-    Transcript,
-    TranscriptDTO,
-)
+from core.videos.transcripts.models import TranscriptDTO
 from core.videos.transcripts.service import TranscriptService
 
 

--- a/core/videos/transcripts/models.py
+++ b/core/videos/transcripts/models.py
@@ -1,31 +1,12 @@
-from typing import Any
-from uuid import UUID, uuid4
-
 from litestar.dto import DTOConfig
 from litestar.plugins.pydantic import PydanticDTO
-from pydantic import BaseModel, Field
 
-
-class TranscriptSentence(BaseModel):
-    id: UUID = Field(default_factory=uuid4)
-    source: str  # Speech-to-text, OCR, etc
-    text: str  # The actual text of the sentence
-    start_time_s: float  # Start time in seconds
-    embedding: list[float] = []
-    metadata: dict[str, Any] = {}
-
-
-class Transcript(BaseModel):
-    video_id: UUID | None
-    sentences: list[TranscriptSentence]
+from core.models import Transcript
 
 
 class TranscriptDTO(PydanticDTO[Transcript]):
     config = DTOConfig(
         exclude={
             "video_id",
-            "sentences.*.embedding",
         },
     )
-
-

--- a/core/videos/transcripts/repo.py
+++ b/core/videos/transcripts/repo.py
@@ -7,7 +7,7 @@ from psycopg.types.json import Jsonb
 
 from core.analysis import embedding
 from core.errors import ConflictError
-from core.videos.transcripts.models import TranscriptSentence
+from core.models import TranscriptSentence
 
 
 class TranscriptRepository:
@@ -31,7 +31,7 @@ class TranscriptRepository:
                     %(metadata)s,
                     %(embedding)s
                 )
-                RETURNING *, embedding::real[]
+                RETURNING *
                 """,
                 [
                     x.model_dump()
@@ -63,7 +63,7 @@ class TranscriptRepository:
     ) -> list[TranscriptSentence]:
         await self._session.execute(
             """
-            SELECT *, embedding::real[] FROM transcript_sentences
+            SELECT * FROM transcript_sentences
             WHERE video_id = %(video_id)s
             ORDER BY start_time_s ASC
             """,

--- a/core/videos/transcripts/service.py
+++ b/core/videos/transcripts/service.py
@@ -3,8 +3,8 @@ from uuid import UUID
 
 from litestar.dto import DTOData
 
+from core.models import Transcript
 from core.uow import ConnectionFactory, uow
-from core.videos.transcripts.models import Transcript
 from core.videos.transcripts.repo import TranscriptRepository
 
 

--- a/tests/videos/conftest.py
+++ b/tests/videos/conftest.py
@@ -5,9 +5,8 @@ from litestar.testing import AsyncTestClient
 from polyfactory.factories.pydantic_factory import ModelFactory
 from pytest import fixture
 
+from core.models import Transcript, Video
 from core.videos.claims.models import VideoClaims
-from core.videos.models import Video
-from core.videos.transcripts.models import Transcript
 
 
 class VideoFactory(ModelFactory[Video]):

--- a/tests/videos/controller_test.py
+++ b/tests/videos/controller_test.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY
 from litestar import Litestar
 from litestar.testing import AsyncTestClient
 
-from core.videos.models import Video
+from core.models import Video
 from tests.videos.conftest import VideoFactory, create_video
 
 
@@ -18,7 +18,7 @@ async def test_add_video(
         json=video_json,
     )
     assert response.status_code == 201
-    assert response.json() == {"data": video_json | {"embedding": ANY}}
+    assert response.json() == {"data": video_json}
 
 
 async def test_get_video(
@@ -30,7 +30,6 @@ async def test_get_video(
     assert response.json() == {
         "data": video.model_dump(mode="json")
         | {
-            "embedding": ANY,
             "transcript": ANY,
             "claims": ANY,
             "narratives": ANY,
@@ -75,7 +74,7 @@ async def test_update_video(
     )
     assert update_response.status_code == 200
     assert update_response.json() == {
-        "data": video.model_dump(mode="json") | updated_fields | {"embedding": ANY}
+        "data": video.model_dump(mode="json") | updated_fields
     }
 
 
@@ -96,7 +95,6 @@ async def test_filter_cursor(
     videos = []
     for _ in range(5):
         video = (await create_video(api_key_client)).model_dump(mode="json")
-        video["embedding"] = ANY
         videos.append(video)
     videos = videos[::-1]
 

--- a/tests/videos/transcripts/controller_test.py
+++ b/tests/videos/transcripts/controller_test.py
@@ -1,10 +1,7 @@
-from unittest.mock import ANY
-
 from litestar import Litestar
 from litestar.testing import AsyncTestClient
 
-from core.videos.models import Video
-from core.videos.transcripts.models import Transcript
+from core.models import Transcript, Video
 from tests.videos.conftest import TranscriptFactory
 
 
@@ -19,7 +16,6 @@ async def test_add_transcript(
         json=transcript_json,
     )
     assert response.status_code == 201
-    transcript_json["sentences"][0]["embedding"] = ANY
     assert response.json() | {"data": transcript_json} == response.json()
 
 
@@ -37,7 +33,6 @@ async def test_get_transcript(
     response = await api_key_client.get(f"/api/videos/{video.id}/transcript")
     assert response.status_code == 200
     transcript_json = transcript.model_dump(mode="json")
-    transcript_json["sentences"][0]["embedding"] = ANY
     assert response.json() == {"data": transcript_json}
 
 


### PR DESCRIPTION
This looks a lot bigger than it is. 

It does 3 things:
1) Moves shared models from their respective `core.<package>.models` module to a shared `core.models` module. This avoid import loops and lets us use proper types instead of `Any` in quite a few places.
2) Removes embeddings from API responses and tidys up some of the models and work that was previously required to avoid returning them.
3) Fixes tests, types and linter errors (line length, quotes, etc.)