### PR TITLE
feat: implement alert system

### DIFF
--- a/core/alerts/background.py
+++ b/core/alerts/background.py
@@ -1,0 +1,27 @@
+"""Background tasks for the alert system."""
+
+from typing import Any
+
+from core.email import Emailer
+
+
+async def send_alert_email(
+    emailer: Emailer,
+    to: str,
+    subject: str,
+    body: str,
+    alert_ids: list[str],
+) -> None:
+    """Send alert email as a background task.
+    
+    Args:
+        emailer: The email service
+        to: Recipient email address
+        subject: Email subject
+        body: HTML email body
+        alert_ids: List of alert IDs for logging
+    """
+    
+    emailer.send(to, subject, body)
+    
+    print(f"Sent alert email to {to} for alerts: {alert_ids}")

--- a/core/alerts/background.py
+++ b/core/alerts/background.py
@@ -1,8 +1,11 @@
 """Background tasks for the alert system."""
 
+import logging
 from typing import Any
 
 from core.email import Emailer
+
+log = logging.getLogger(__name__)
 
 
 async def send_alert_email(
@@ -24,4 +27,4 @@ async def send_alert_email(
     
     emailer.send(to, subject, body)
     
-    print(f"Sent alert email to {to} for alerts: {alert_ids}")
+    log.info(f"Sent alert email to {to} for alerts: {alert_ids}")

--- a/core/alerts/controller.py
+++ b/core/alerts/controller.py
@@ -35,6 +35,7 @@ class AlertController(Controller):
     ) -> Alert:
         return await alert_service.create_alert(
             identity=request.user,
+            name=data.name,
             alert_type=data.alert_type,
             scope=data.scope,
             narrative_id=data.narrative_id,
@@ -98,6 +99,7 @@ class AlertController(Controller):
         return await alert_service.update_alert(
             alert_id=alert_id,
             identity=request.user,
+            name=data.name,
             enabled=data.enabled,
             threshold=data.threshold,
             keyword=data.keyword,

--- a/core/alerts/controller.py
+++ b/core/alerts/controller.py
@@ -1,0 +1,186 @@
+from typing import Any
+from uuid import UUID
+
+from litestar import Controller, Request, delete, get, patch, post
+from litestar.di import Provide
+from litestar.status_codes import HTTP_204_NO_CONTENT
+
+from core.alerts.models import Alert, AlertScope, AlertType, CreateAlertRequest, UpdateAlertRequest
+from core.alerts.service import AlertService
+from core.auth.models import AuthToken, Identity
+from core.response import PaginatedJSON
+
+
+def alert_service(connection_factory: Any) -> AlertService:
+    return AlertService(connection_factory=connection_factory)
+
+
+class AlertController(Controller):
+    path = "/alerts"
+    tags = ["alerts"]
+    dependencies = {
+        "alert_service": Provide(alert_service, sync_to_thread=False),
+    }
+
+    @post(
+        path="/",
+        summary="Create a new alert",
+        description="Create a new alert for the authenticated user and organisation",
+    )
+    async def create_alert(
+        self,
+        request: Request[Identity, AuthToken, Any],
+        alert_service: AlertService,
+        data: CreateAlertRequest,
+    ) -> Alert:
+        return await alert_service.create_alert(
+            identity=request.user,
+            alert_type=data.alert_type,
+            scope=data.scope,
+            narrative_id=data.narrative_id,
+            threshold=data.threshold,
+            topic_id=data.topic_id,
+            keyword=data.keyword,
+            metadata=data.metadata,
+        )
+
+    @get(
+        path="/",
+        summary="Get user alerts",
+        description="Get all alerts for the authenticated user and organisation",
+    )
+    async def get_alerts(
+        self,
+        request: Request[Identity, AuthToken, Any],
+        alert_service: AlertService,
+        enabled_only: bool = False,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> PaginatedJSON[list[Alert]]:
+        alerts, total = await alert_service.get_user_alerts(
+            identity=request.user,
+            enabled_only=enabled_only,
+            limit=limit,
+            offset=offset,
+        )
+        return PaginatedJSON(
+            data=alerts,
+            total=total,
+            page=offset // limit + 1,
+            size=limit,
+        )
+
+    @get(
+        path="/{alert_id:uuid}",
+        summary="Get a specific alert",
+        description="Get details of a specific alert",
+    )
+    async def get_alert(
+        self,
+        alert_id: UUID,
+        request: Request[Identity, AuthToken, Any],
+        alert_service: AlertService,
+    ) -> Alert:
+        return await alert_service.get_alert(alert_id, request.user)
+
+    @patch(
+        path="/{alert_id:uuid}",
+        summary="Update an alert",
+        description="Update an existing alert",
+    )
+    async def update_alert(
+        self,
+        alert_id: UUID,
+        request: Request[Identity, AuthToken, Any],
+        alert_service: AlertService,
+        data: UpdateAlertRequest,
+    ) -> Alert:
+        return await alert_service.update_alert(
+            alert_id=alert_id,
+            identity=request.user,
+            enabled=data.enabled,
+            threshold=data.threshold,
+            keyword=data.keyword,
+        )
+
+    @delete(
+        path="/{alert_id:uuid}",
+        summary="Delete an alert",
+        description="Delete an existing alert",
+        status_code=HTTP_204_NO_CONTENT,
+    )
+    async def delete_alert(
+        self,
+        alert_id: UUID,
+        request: Request[Identity, AuthToken, Any],
+        alert_service: AlertService,
+    ) -> None:
+        await alert_service.delete_alert(alert_id, request.user)
+
+    # TODO: Add endpoint to manually trigger alert processing
+    # This would use BackgroundTask to send emails asynchronously:
+    # @post(
+    #     path="/process",
+    #     summary="Manually process alerts (admin only)",
+    # )
+    # async def process_alerts_manual(
+    #     self,
+    #     alert_service: AlertService,
+    # ) -> Response[AlertExecution]:
+    #     execution = await alert_service.process_alerts()
+    #     return Response(
+    #         execution,
+    #         background=BackgroundTask(send_alert_emails, ...)
+    #     )
+    
+    @get(
+        path="/types",
+        summary="Get available alert types",
+        description="Get list of available alert types and their descriptions",
+    )
+    async def get_alert_types(self) -> dict:
+        return {
+            "types": [
+                {
+                    "value": AlertType.NARRATIVE_VIEWS.value,
+                    "description": "Alert when narrative views exceed threshold",
+                    "requires": ["threshold"],
+                    "scopes": ["general", "specific"],
+                },
+                {
+                    "value": AlertType.NARRATIVE_CLAIMS_COUNT.value,
+                    "description": "Alert when narrative claims count exceeds threshold",
+                    "requires": ["threshold"],
+                    "scopes": ["general", "specific"],
+                },
+                {
+                    "value": AlertType.NARRATIVE_VIDEOS_COUNT.value,
+                    "description": "Alert when narrative videos count exceeds threshold",
+                    "requires": ["threshold"],
+                    "scopes": ["general", "specific"],
+                },
+                {
+                    "value": AlertType.NARRATIVE_WITH_TOPIC.value,
+                    "description": "Alert when new narrative with specific topic is created",
+                    "requires": ["topic_id"],
+                    "scopes": ["general"],
+                },
+                {
+                    "value": AlertType.KEYWORD.value,
+                    "description": "Alert when narrative contains specific keyword",
+                    "requires": ["keyword"],
+                    "scopes": ["general"],
+                },
+            ],
+            "scopes": [
+                {
+                    "value": AlertScope.GENERAL.value,
+                    "description": "Apply to all narratives",
+                },
+                {
+                    "value": AlertScope.SPECIFIC.value,
+                    "description": "Apply to specific narrative only",
+                    "requires": ["narrative_id"],
+                },
+            ],
+        }

--- a/core/alerts/models.py
+++ b/core/alerts/models.py
@@ -23,6 +23,7 @@ class Alert(BaseModel):
     id: UUID = Field(default_factory=uuid4)
     user_id: UUID
     organisation_id: UUID
+    name: str
     alert_type: AlertType
     scope: AlertScope
     narrative_id: UUID | None = None
@@ -60,12 +61,14 @@ class CreateAlertRequest(BaseModel):
         json_schema_extra={
             "examples": [
                 {
+                    "name": "High View Count Alert",
                     "alert_type": "narrative_views",
                     "scope": "general",
-                    "threshold": 1000,
-                    "metadata": {"description": "Alert when any narrative exceeds 1000 views"}
+                    "threshold": 100000,
+                    "metadata": {"description": "Alert when any narrative exceeds 100000 views"}
                 },
                 {
+                    "name": "Claims Threshold Alert",
                     "alert_type": "narrative_claims_count",
                     "scope": "specific",
                     "narrative_id": "123e4567-e89b-12d3-a456-426614174000",
@@ -73,12 +76,14 @@ class CreateAlertRequest(BaseModel):
                     "metadata": {"description": "Alert when specific narrative has 50+ claims"}
                 },
                 {
+                    "name": "Climate Topic Monitor",
                     "alert_type": "narrative_with_topic",
                     "scope": "general",
                     "topic_id": "456e7890-e89b-12d3-a456-426614174000",
                     "metadata": {"description": "Alert for new narratives with climate topic"}
                 },
                 {
+                    "name": "Vaccine Keyword Tracker",
                     "alert_type": "keyword",
                     "scope": "general",
                     "keyword": "vaccine",
@@ -88,6 +93,7 @@ class CreateAlertRequest(BaseModel):
         }
     )
     
+    name: str = Field(..., description="Name to identify the alert", min_length=1, max_length=255)
     alert_type: AlertType = Field(..., description="Type of alert to create")
     scope: AlertScope = Field(..., description="Scope of the alert (general for all narratives, specific for one)")
     narrative_id: UUID | None = Field(None, description="Required for specific scope alerts. Cannot be used with general scope")
@@ -148,9 +154,11 @@ class UpdateAlertRequest(BaseModel):
         json_schema_extra={
             "examples": [
                 {
+                    "name": "Updated Alert Name",
                     "enabled": False
                 },
                 {
+                    "name": "High Priority Alert",
                     "threshold": 2000,
                     "enabled": True
                 },
@@ -161,6 +169,7 @@ class UpdateAlertRequest(BaseModel):
         }
     )
     
+    name: str | None = Field(None, description="New name for the alert", min_length=1, max_length=255)
     enabled: bool | None = Field(None, description="Enable or disable the alert")
     threshold: int | None = Field(None, description="New threshold value", ge=1)
     keyword: str | None = Field(None, description="New keyword to search for", min_length=1, max_length=255)

--- a/core/alerts/models.py
+++ b/core/alerts/models.py
@@ -1,0 +1,167 @@
+from datetime import datetime
+from enum import Enum
+from typing import Any, Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field, ConfigDict, model_validator
+
+
+class AlertType(str, Enum):
+    NARRATIVE_VIEWS = "narrative_views"
+    NARRATIVE_CLAIMS_COUNT = "narrative_claims_count"
+    NARRATIVE_VIDEOS_COUNT = "narrative_videos_count"
+    NARRATIVE_WITH_TOPIC = "narrative_with_topic"
+    KEYWORD = "keyword"
+
+
+class AlertScope(str, Enum):
+    GENERAL = "general"
+    SPECIFIC = "specific"
+
+
+class Alert(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    user_id: UUID
+    organisation_id: UUID
+    alert_type: AlertType
+    scope: AlertScope
+    narrative_id: UUID | None = None
+    threshold: int | None = None
+    topic_id: UUID | None = None
+    keyword: str | None = None
+    enabled: bool = True
+    metadata: dict[str, Any] = {}
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class AlertExecution(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    executed_at: datetime
+    alerts_checked: int
+    alerts_triggered: int
+    emails_sent: int
+    metadata: dict[str, Any] = {}
+
+
+class AlertTriggered(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    alert_id: UUID
+    narrative_id: UUID
+    triggered_at: datetime
+    trigger_value: int | None = None
+    threshold_crossed: int | None = None
+    notification_sent: bool = False
+    metadata: dict[str, Any] = {}
+
+
+class CreateAlertRequest(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "alert_type": "narrative_views",
+                    "scope": "general",
+                    "threshold": 1000,
+                    "metadata": {"description": "Alert when any narrative exceeds 1000 views"}
+                },
+                {
+                    "alert_type": "narrative_claims_count",
+                    "scope": "specific",
+                    "narrative_id": "123e4567-e89b-12d3-a456-426614174000",
+                    "threshold": 50,
+                    "metadata": {"description": "Alert when specific narrative has 50+ claims"}
+                },
+                {
+                    "alert_type": "narrative_with_topic",
+                    "scope": "general",
+                    "topic_id": "456e7890-e89b-12d3-a456-426614174000",
+                    "metadata": {"description": "Alert for new narratives with climate topic"}
+                },
+                {
+                    "alert_type": "keyword",
+                    "scope": "general",
+                    "keyword": "vaccine",
+                    "metadata": {"description": "Alert when narratives mention 'vaccine'"}
+                }
+            ]
+        }
+    )
+    
+    alert_type: AlertType = Field(..., description="Type of alert to create")
+    scope: AlertScope = Field(..., description="Scope of the alert (general for all narratives, specific for one)")
+    narrative_id: UUID | None = Field(None, description="Required for specific scope alerts. Cannot be used with general scope")
+    threshold: int | None = Field(None, description="Required for narrative_views, narrative_claims_count, narrative_videos_count alerts", ge=1)
+    topic_id: UUID | None = Field(None, description="Required for narrative_with_topic alerts only")
+    keyword: str | None = Field(None, description="Required for keyword alerts only", min_length=1, max_length=255)
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata for the alert")
+    
+    @model_validator(mode='after')
+    def validate_alert_fields(self):
+        # Validate scope and narrative_id combination
+        if self.scope == AlertScope.GENERAL and self.narrative_id is not None:
+            raise ValueError("General scope alerts cannot have a narrative_id")
+        
+        if self.scope == AlertScope.SPECIFIC and self.narrative_id is None:
+            raise ValueError("Specific scope alerts require a narrative_id")
+        
+        # Validate alert type specific fields
+        threshold_types = {
+            AlertType.NARRATIVE_VIEWS,
+            AlertType.NARRATIVE_CLAIMS_COUNT,
+            AlertType.NARRATIVE_VIDEOS_COUNT
+        }
+        
+        if self.alert_type in threshold_types:
+            if self.threshold is None:
+                raise ValueError(f"{self.alert_type.value} alerts require a threshold")
+            if self.topic_id is not None:
+                raise ValueError(f"{self.alert_type.value} alerts cannot have a topic_id")
+            if self.keyword is not None:
+                raise ValueError(f"{self.alert_type.value} alerts cannot have a keyword")
+        
+        elif self.alert_type == AlertType.NARRATIVE_WITH_TOPIC:
+            if self.topic_id is None:
+                raise ValueError("narrative_with_topic alerts require a topic_id")
+            if self.threshold is not None:
+                raise ValueError("narrative_with_topic alerts cannot have a threshold")
+            if self.keyword is not None:
+                raise ValueError("narrative_with_topic alerts cannot have a keyword")
+            if self.scope != AlertScope.GENERAL:
+                raise ValueError("narrative_with_topic alerts must have general scope")
+        
+        elif self.alert_type == AlertType.KEYWORD:
+            if self.keyword is None:
+                raise ValueError("keyword alerts require a keyword")
+            if self.threshold is not None:
+                raise ValueError("keyword alerts cannot have a threshold")
+            if self.topic_id is not None:
+                raise ValueError("keyword alerts cannot have a topic_id")
+            if self.scope != AlertScope.GENERAL:
+                raise ValueError("keyword alerts must have general scope")
+        
+        return self
+
+
+class UpdateAlertRequest(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "enabled": False
+                },
+                {
+                    "threshold": 2000,
+                    "enabled": True
+                },
+                {
+                    "keyword": "climate change"
+                }
+            ]
+        }
+    )
+    
+    enabled: bool | None = Field(None, description="Enable or disable the alert")
+    threshold: int | None = Field(None, description="New threshold value", ge=1)
+    keyword: str | None = Field(None, description="New keyword to search for", min_length=1, max_length=255)
+    metadata: dict[str, Any] = {}

--- a/core/alerts/repo.py
+++ b/core/alerts/repo.py
@@ -90,7 +90,8 @@ class AlertRepository:
             f"SELECT COUNT(*) FROM alerts WHERE {where_clause}",
             base_params,
         )
-        total = (await self._session.fetchone())["count"]
+        count_row = await self._session.fetchone()
+        total = count_row["count"] if count_row else 0
 
         # Get paginated results
         await self._session.execute(
@@ -116,7 +117,7 @@ class AlertRepository:
         keyword: str | None = None,
     ) -> Alert | None:
         updates = []
-        params = {"alert_id": alert_id}
+        params: dict[str, UUID | str | bool | int] = {"alert_id": alert_id}
 
         if name is not None:
             updates.append("name = %(name)s")

--- a/core/alerts/repo.py
+++ b/core/alerts/repo.py
@@ -18,6 +18,7 @@ class AlertRepository:
         self,
         user_id: UUID,
         organisation_id: UUID,
+        name: str,
         alert_type: AlertType,
         scope: AlertScope,
         narrative_id: UUID | None = None,
@@ -30,10 +31,10 @@ class AlertRepository:
             await self._session.execute(
                 """
                 INSERT INTO alerts (
-                    user_id, organisation_id, alert_type, scope,
+                    user_id, organisation_id, name, alert_type, scope,
                     narrative_id, threshold, topic_id, keyword, metadata
                 ) VALUES (
-                    %(user_id)s, %(organisation_id)s, %(alert_type)s, %(scope)s,
+                    %(user_id)s, %(organisation_id)s, %(name)s, %(alert_type)s, %(scope)s,
                     %(narrative_id)s, %(threshold)s, %(topic_id)s, %(keyword)s, %(metadata)s
                 )
                 RETURNING *
@@ -41,6 +42,7 @@ class AlertRepository:
                 {
                     "user_id": user_id,
                     "organisation_id": organisation_id,
+                    "name": name,
                     "alert_type": alert_type.value,
                     "scope": scope.value,
                     "narrative_id": narrative_id,
@@ -108,12 +110,17 @@ class AlertRepository:
     async def update_alert(
         self,
         alert_id: UUID,
+        name: str | None = None,
         enabled: bool | None = None,
         threshold: int | None = None,
         keyword: str | None = None,
     ) -> Alert | None:
         updates = []
         params = {"alert_id": alert_id}
+
+        if name is not None:
+            updates.append("name = %(name)s")
+            params["name"] = name
 
         if enabled is not None:
             updates.append("enabled = %(enabled)s")
@@ -344,6 +351,7 @@ class AlertRepository:
                 id=row["id"],
                 user_id=row["user_id"],
                 organisation_id=row["organisation_id"],
+                name=row.get("name", "Unnamed Alert"),
                 alert_type=row["alert_type"],
                 scope=row["scope"],
                 narrative_id=row["narrative_id"],
@@ -384,6 +392,7 @@ class AlertRepository:
                 id=row["id"],
                 user_id=row["user_id"],
                 organisation_id=row["organisation_id"],
+                name=row.get("name", "Unnamed Alert"),
                 alert_type=row["alert_type"],
                 scope=row["scope"],
                 narrative_id=row["narrative_id"],
@@ -430,6 +439,7 @@ class AlertRepository:
                 id=row["id"],
                 user_id=row["user_id"],
                 organisation_id=row["organisation_id"],
+                name=row.get("name", "Unnamed Alert"),
                 alert_type=row["alert_type"],
                 scope=row["scope"],
                 narrative_id=row["narrative_id"],

--- a/core/alerts/repo.py
+++ b/core/alerts/repo.py
@@ -1,0 +1,446 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+import psycopg
+from psycopg.rows import DictRow
+from psycopg.types.json import Jsonb
+
+from core.alerts.models import Alert, AlertExecution, AlertScope, AlertTriggered, AlertType
+from core.errors import ConflictError
+
+
+class AlertRepository:
+    def __init__(self, session: psycopg.AsyncCursor[DictRow]) -> None:
+        self._session = session
+
+    async def create_alert(
+        self,
+        user_id: UUID,
+        organisation_id: UUID,
+        alert_type: AlertType,
+        scope: AlertScope,
+        narrative_id: UUID | None = None,
+        threshold: int | None = None,
+        topic_id: UUID | None = None,
+        keyword: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Alert:
+        try:
+            await self._session.execute(
+                """
+                INSERT INTO alerts (
+                    user_id, organisation_id, alert_type, scope,
+                    narrative_id, threshold, topic_id, keyword, metadata
+                ) VALUES (
+                    %(user_id)s, %(organisation_id)s, %(alert_type)s, %(scope)s,
+                    %(narrative_id)s, %(threshold)s, %(topic_id)s, %(keyword)s, %(metadata)s
+                )
+                RETURNING *
+                """,
+                {
+                    "user_id": user_id,
+                    "organisation_id": organisation_id,
+                    "alert_type": alert_type.value,
+                    "scope": scope.value,
+                    "narrative_id": narrative_id,
+                    "threshold": threshold,
+                    "topic_id": topic_id,
+                    "keyword": keyword,
+                    "metadata": Jsonb(metadata or {}),
+                },
+            )
+        except psycopg.errors.UniqueViolation:
+            raise ConflictError("Alert already exists")
+
+        row = await self._session.fetchone()
+        if not row:
+            raise ValueError("Failed to create alert")
+
+        return Alert(**row)
+
+    async def get_alert(self, alert_id: UUID) -> Alert | None:
+        await self._session.execute(
+            "SELECT * FROM alerts WHERE id = %(alert_id)s",
+            {"alert_id": alert_id},
+        )
+        row = await self._session.fetchone()
+        return Alert(**row) if row else None
+
+    async def get_user_alerts(
+        self,
+        user_id: UUID,
+        organisation_id: UUID,
+        enabled_only: bool = False,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> tuple[list[Alert], int]:
+        base_params = {"user_id": user_id, "organisation_id": organisation_id}
+        
+        # Build WHERE clause conditionally
+        where_conditions = ["user_id = %(user_id)s", "organisation_id = %(organisation_id)s"]
+        if enabled_only:
+            where_conditions.append("enabled = TRUE")
+        where_clause = " AND ".join(where_conditions)
+
+        # Get total count
+        await self._session.execute(
+            f"SELECT COUNT(*) FROM alerts WHERE {where_clause}",
+            base_params,
+        )
+        total = (await self._session.fetchone())["count"]
+
+        # Get paginated results
+        await self._session.execute(
+            f"""
+            SELECT * FROM alerts
+            WHERE {where_clause}
+            ORDER BY created_at DESC
+            LIMIT %(limit)s OFFSET %(offset)s
+            """,
+            {**base_params, "limit": limit, "offset": offset},
+        )
+        rows = await self._session.fetchall()
+        alerts = [Alert(**row) for row in rows]
+
+        return alerts, total
+
+    async def update_alert(
+        self,
+        alert_id: UUID,
+        enabled: bool | None = None,
+        threshold: int | None = None,
+        keyword: str | None = None,
+    ) -> Alert | None:
+        updates = []
+        params = {"alert_id": alert_id}
+
+        if enabled is not None:
+            updates.append("enabled = %(enabled)s")
+            params["enabled"] = enabled
+
+        if threshold is not None:
+            updates.append("threshold = %(threshold)s")
+            params["threshold"] = threshold
+
+        if keyword is not None:
+            updates.append("keyword = %(keyword)s")
+            params["keyword"] = keyword
+
+        if not updates:
+            return await self.get_alert(alert_id)
+
+        updates.append("updated_at = CURRENT_TIMESTAMP")
+
+        await self._session.execute(
+            f"""
+            UPDATE alerts
+            SET {', '.join(updates)}
+            WHERE id = %(alert_id)s
+            RETURNING *
+            """,
+            params,
+        )
+        row = await self._session.fetchone()
+        return Alert(**row) if row else None
+
+    async def delete_alert(self, alert_id: UUID) -> bool:
+        await self._session.execute(
+            "DELETE FROM alerts WHERE id = %(alert_id)s",
+            {"alert_id": alert_id},
+        )
+        return self._session.rowcount > 0
+
+    async def get_active_alerts(self) -> list[Alert]:
+        await self._session.execute(
+            """
+            SELECT * FROM alerts
+            WHERE enabled = TRUE
+            ORDER BY created_at
+            """
+        )
+        rows = await self._session.fetchall()
+        return [Alert(**row) for row in rows]
+
+    async def record_alert_trigger(
+        self,
+        alert_id: UUID,
+        narrative_id: UUID,
+        trigger_value: int | None = None,
+        threshold_crossed: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> AlertTriggered | None:
+        try:
+            await self._session.execute(
+                """
+                INSERT INTO alerts_triggered (
+                    alert_id, narrative_id, trigger_value, threshold_crossed, metadata
+                ) VALUES (
+                    %(alert_id)s, %(narrative_id)s, %(trigger_value)s, %(threshold_crossed)s, %(metadata)s
+                )
+                ON CONFLICT (alert_id, narrative_id, threshold_crossed) DO NOTHING
+                RETURNING *
+                """,
+                {
+                    "alert_id": alert_id,
+                    "narrative_id": narrative_id,
+                    "trigger_value": trigger_value,
+                    "threshold_crossed": threshold_crossed,
+                    "metadata": Jsonb(metadata or {}),
+                },
+            )
+            row = await self._session.fetchone()
+            return AlertTriggered(**row) if row else None
+        except psycopg.errors.UniqueViolation:
+            return None  # Alert already triggered for this combination
+
+    async def mark_notification_sent(self, triggered_id: UUID) -> bool:
+        await self._session.execute(
+            """
+            UPDATE alerts_triggered
+            SET notification_sent = TRUE
+            WHERE id = %(triggered_id)s
+            """,
+            {"triggered_id": triggered_id},
+        )
+        return self._session.rowcount > 0
+
+    async def get_pending_notifications(
+        self, since: datetime | None = None
+    ) -> list[AlertTriggered]:
+        where_clause = "WHERE notification_sent = FALSE"
+        params = {}
+
+        if since:
+            where_clause += " AND triggered_at >= %(since)s"
+            params["since"] = since
+
+        await self._session.execute(
+            f"""
+            SELECT * FROM alerts_triggered
+            {where_clause}
+            ORDER BY triggered_at
+            """,
+            params,
+        )
+        rows = await self._session.fetchall()
+        return [AlertTriggered(**row) for row in rows]
+
+    async def record_execution(
+        self,
+        alerts_checked: int,
+        alerts_triggered: int,
+        emails_sent: int,
+        metadata: dict[str, Any] | None = None,
+    ) -> AlertExecution:
+        await self._session.execute(
+            """
+            INSERT INTO alert_executions (
+                alerts_checked, alerts_triggered, emails_sent, metadata
+            ) VALUES (
+                %(alerts_checked)s, %(alerts_triggered)s, %(emails_sent)s, %(metadata)s
+            )
+            RETURNING *
+            """,
+            {
+                "alerts_checked": alerts_checked,
+                "alerts_triggered": alerts_triggered,
+                "emails_sent": emails_sent,
+                "metadata": Jsonb(metadata or {}),
+            },
+        )
+        row = await self._session.fetchone()
+        if not row:
+            raise ValueError("Failed to record execution")
+
+        return AlertExecution(**row)
+
+    async def get_last_execution(self) -> AlertExecution | None:
+        await self._session.execute(
+            """
+            SELECT * FROM alert_executions
+            ORDER BY executed_at DESC
+            LIMIT 1
+            """
+        )
+        row = await self._session.fetchone()
+        return AlertExecution(**row) if row else None
+
+    async def check_narrative_stats_alerts(
+        self, since: datetime | None = None
+    ) -> list[tuple[Alert, UUID, int]]:
+        """Check for narrative stats alerts that should be triggered.
+        Returns list of (alert, narrative_id, current_value) tuples."""
+        
+        # For general alerts, check all narratives
+        # For specific alerts, only check the specified narrative
+        query = """
+            WITH narrative_stats AS (
+                SELECT 
+                    n.id AS narrative_id,
+                    SUM(COALESCE(v.views, 0)) AS total_views,
+                    COUNT(DISTINCT cn.claim_id) AS claims_count,
+                    COUNT(DISTINCT v.id) AS videos_count
+                FROM narratives n
+                LEFT JOIN claim_narratives cn ON n.id = cn.narrative_id
+                LEFT JOIN claims c ON cn.claim_id = c.id
+                LEFT JOIN videos v ON c.video_id = v.id
+                WHERE (%(since)s IS NULL OR n.created_at >= %(since)s)
+                GROUP BY n.id
+            ),
+            relevant_alerts AS (
+                SELECT
+                    a.id,
+                    a.user_id,
+                    a.organisation_id,
+                    a.alert_type,
+                    a.scope,
+                    a.narrative_id AS specific_narrative,
+                    a.threshold,
+                    a.topic_id,
+                    a.keyword,
+                    a.enabled,
+                    a.metadata,
+                    a.created_at,
+                    a.updated_at
+                FROM alerts a
+                WHERE
+                    a.enabled = TRUE
+                    AND a.alert_type IN (
+                        'narrative_views',
+                        'narrative_claims_count',
+                        'narrative_videos_count'
+                    )
+            )
+            SELECT
+                ra.*,
+                ns.narrative_id,
+                CASE ra.alert_type
+                    WHEN 'narrative_views' THEN ns.total_views
+                    WHEN 'narrative_claims_count' THEN ns.claims_count
+                    WHEN 'narrative_videos_count' THEN ns.videos_count
+                END AS current_value
+            FROM relevant_alerts ra
+            -- join general alerts to all narratives
+            LEFT JOIN narrative_stats ns
+                ON ra.scope = 'general'
+            -- join specific alerts only to their narrative
+                OR (ra.scope = 'specific' 
+                    AND ra.specific_narrative = ns.narrative_id)
+            WHERE
+                CASE ra.alert_type
+                    WHEN 'narrative_views' THEN ns.total_views
+                    WHEN 'narrative_claims_count' THEN ns.claims_count
+                    WHEN 'narrative_videos_count' THEN ns.videos_count
+                END >= ra.threshold
+        """
+        
+        await self._session.execute(query, {"since": since})
+        rows = await self._session.fetchall()
+        
+        results = []
+        for row in rows:
+            alert = Alert(
+                id=row["id"],
+                user_id=row["user_id"],
+                organisation_id=row["organisation_id"],
+                alert_type=row["alert_type"],
+                scope=row["scope"],
+                narrative_id=row["narrative_id"],
+                threshold=row["threshold"],
+                topic_id=row["topic_id"],
+                keyword=row["keyword"],
+                enabled=row["enabled"],
+                metadata=row["metadata"],
+                created_at=row["created_at"],
+                updated_at=row["updated_at"],
+            )
+            results.append((alert, row["narrative_id"], row["current_value"]))
+        
+        return results
+
+    async def check_topic_alerts(
+        self, since: datetime | None = None
+    ) -> list[tuple[Alert, UUID]]:
+        """Check for new narratives with tracked topics.
+        Returns list of (alert, narrative_id) tuples."""
+        
+        query = """
+            SELECT DISTINCT a.*, nt.narrative_id
+            FROM alerts a
+            JOIN narrative_topics nt ON a.topic_id = nt.topic_id
+            JOIN narratives n ON nt.narrative_id = n.id
+            WHERE a.enabled = TRUE
+            AND a.alert_type = 'narrative_with_topic'
+            AND (%(since)s IS NULL OR n.created_at >= %(since)s)
+        """
+        
+        await self._session.execute(query, {"since": since})
+        rows = await self._session.fetchall()
+        
+        results = []
+        for row in rows:
+            alert = Alert(
+                id=row["id"],
+                user_id=row["user_id"],
+                organisation_id=row["organisation_id"],
+                alert_type=row["alert_type"],
+                scope=row["scope"],
+                narrative_id=row["narrative_id"],
+                threshold=row["threshold"],
+                topic_id=row["topic_id"],
+                keyword=row["keyword"],
+                enabled=row["enabled"],
+                metadata=row["metadata"],
+                created_at=row["created_at"],
+                updated_at=row["updated_at"],
+            )
+            results.append((alert, row["narrative_id"]))
+        
+        return results
+
+    async def check_keyword_alerts(
+        self, since: datetime | None = None
+    ) -> list[tuple[Alert, UUID]]:
+        """Check for narratives containing tracked keywords.
+        Returns list of (alert, narrative_id) tuples."""
+        
+        query = """
+            WITH recent_narratives AS (
+                SELECT id, title, description 
+                FROM narratives 
+                WHERE (%(since)s IS NULL OR created_at >= %(since)s)
+            )
+            SELECT DISTINCT a.*, n.id as narrative_id
+            FROM alerts a
+            JOIN recent_narratives n ON (
+                LOWER(n.title) LIKE LOWER('%%' || a.keyword || '%%')
+                OR LOWER(n.description) LIKE LOWER('%%' || a.keyword || '%%')
+            )
+            WHERE a.enabled = TRUE
+            AND a.alert_type = 'keyword'
+        """
+        
+        await self._session.execute(query, {"since": since})
+        rows = await self._session.fetchall()
+        
+        results = []
+        for row in rows:
+            alert = Alert(
+                id=row["id"],
+                user_id=row["user_id"],
+                organisation_id=row["organisation_id"],
+                alert_type=row["alert_type"],
+                scope=row["scope"],
+                narrative_id=row["narrative_id"],
+                threshold=row["threshold"],
+                topic_id=row["topic_id"],
+                keyword=row["keyword"],
+                enabled=row["enabled"],
+                metadata=row["metadata"],
+                created_at=row["created_at"],
+                updated_at=row["updated_at"],
+            )
+            results.append((alert, row["narrative_id"]))
+        
+        return results

--- a/core/alerts/service.py
+++ b/core/alerts/service.py
@@ -162,15 +162,15 @@ class AlertService:
                 alerts_triggered = 0
                 triggered_alerts = []
 
-                stats_alerts = await alert_repo.check_narrative_stats_alerts(since=None)
+                stats_alerts = await alert_repo.check_narrative_stats_alerts(since)
                 for alert, narrative_id, current_value in stats_alerts:
                     alerts_checked += 1
                     
                     triggered = await alert_repo.record_alert_trigger(
                         alert_id=alert.id,
                         narrative_id=narrative_id,
-                        trigger_value=current_value,  # Store actual value for logging
-                        threshold_crossed=alert.threshold,  # Use threshold for uniqueness
+                        trigger_value=current_value, 
+                        threshold_crossed=alert.threshold, 
                         metadata={"alert_type": alert.alert_type.value},
                     )
                     

--- a/core/alerts/service.py
+++ b/core/alerts/service.py
@@ -1,0 +1,295 @@
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+from uuid import UUID
+
+from psycopg import AsyncConnection
+from psycopg.rows import DictRow
+
+from core.alerts.models import Alert, AlertExecution, AlertScope, AlertType
+from core.alerts.repo import AlertRepository
+from core.auth.models import Identity
+from core.auth.repo import AuthRepository
+from core.email import get_emailer
+from core.email.messages import alerts_message
+from core.errors import NotAuthorizedError, NotFoundError
+from core.narratives.repo import NarrativeRepository
+
+
+class AlertService:
+    def __init__(
+        self,
+        connection_factory: Callable[[], AsyncConnection[DictRow]],
+    ) -> None:
+        self._connection_factory = connection_factory
+
+    async def create_alert(
+        self,
+        identity: Identity,
+        alert_type: AlertType,
+        scope: AlertScope,
+        narrative_id: UUID | None = None,
+        threshold: int | None = None,
+        topic_id: UUID | None = None,
+        keyword: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Alert:
+        if not identity.organisation:
+            raise NotAuthorizedError("User must belong to an organisation")
+
+        # Validate alert parameters
+        if alert_type in [
+            AlertType.NARRATIVE_VIEWS,
+            AlertType.NARRATIVE_CLAIMS_COUNT,
+            AlertType.NARRATIVE_VIDEOS_COUNT,
+        ]:
+            if threshold is None:
+                raise ValueError(f"Threshold is required for {alert_type.value} alerts")
+
+        if alert_type == AlertType.NARRATIVE_WITH_TOPIC and topic_id is None:
+            raise ValueError("Topic ID is required for topic alerts")
+
+        if alert_type == AlertType.KEYWORD and not keyword:
+            raise ValueError("Keyword is required for keyword alerts")
+
+        if scope == AlertScope.SPECIFIC and narrative_id is None:
+            raise ValueError("Narrative ID is required for specific alerts")
+
+        if scope == AlertScope.GENERAL and narrative_id is not None:
+            raise ValueError("Narrative ID should not be provided for general alerts")
+
+        async with self._connection_factory() as conn:
+            async with conn.cursor() as cur:
+                alert_repo = AlertRepository(cur)
+                return await alert_repo.create_alert(
+                    user_id=identity.user.id,
+                    organisation_id=identity.organisation.id,
+                    alert_type=alert_type,
+                    scope=scope,
+                    narrative_id=narrative_id,
+                    threshold=threshold,
+                    topic_id=topic_id,
+                    keyword=keyword,
+                    metadata=metadata,
+                )
+
+    async def get_alert(self, alert_id: UUID, identity: Identity) -> Alert:
+        async with self._connection_factory() as conn:
+            async with conn.cursor() as cur:
+                alert_repo = AlertRepository(cur)
+                alert = await alert_repo.get_alert(alert_id)
+                
+        if not alert:
+            raise NotFoundError("Alert not found")
+
+        if not identity.organisation or alert.organisation_id != identity.organisation.id:
+            raise NotAuthorizedError("Not authorized to view this alert")
+
+        return alert
+
+    async def get_user_alerts(
+        self,
+        identity: Identity,
+        enabled_only: bool = False,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> tuple[list[Alert], int]:
+        if not identity.organisation:
+            raise NotAuthorizedError("User must belong to an organisation")
+
+        async with self._connection_factory() as conn:
+            async with conn.cursor() as cur:
+                alert_repo = AlertRepository(cur)
+                return await alert_repo.get_user_alerts(
+                    user_id=identity.user.id,
+                    organisation_id=identity.organisation.id,
+                    enabled_only=enabled_only,
+                    limit=limit,
+                    offset=offset,
+                )
+
+    async def update_alert(
+        self,
+        alert_id: UUID,
+        identity: Identity,
+        enabled: bool | None = None,
+        threshold: int | None = None,
+        keyword: str | None = None,
+    ) -> Alert:
+        alert = await self.get_alert(alert_id, identity)
+
+        async with self._connection_factory() as conn:
+            async with conn.cursor() as cur:
+                alert_repo = AlertRepository(cur)
+                updated = await alert_repo.update_alert(
+                    alert_id=alert_id,
+                    enabled=enabled,
+                    threshold=threshold,
+                    keyword=keyword,
+                )
+                
+        if not updated:
+            raise NotFoundError("Alert not found")
+
+        return updated
+
+    async def delete_alert(self, alert_id: UUID, identity: Identity) -> bool:
+        await self.get_alert(alert_id, identity)
+
+        async with self._connection_factory() as conn:
+            async with conn.cursor() as cur:
+                alert_repo = AlertRepository(cur)
+                return await alert_repo.delete_alert(alert_id)
+
+    async def process_alerts(self) -> AlertExecution:
+        """Main method to process all alerts - called by CLI command."""
+        
+        async with self._connection_factory() as conn:
+            async with conn.cursor() as cur:
+                alert_repo = AlertRepository(cur)
+                auth_repo = AuthRepository(cur)
+                narrative_repo = NarrativeRepository(cur)
+                
+                # Get last execution time
+                last_execution = await alert_repo.get_last_execution()
+                since = last_execution.executed_at if last_execution else datetime.now(timezone.utc) - timedelta(hours=1)
+
+                alerts_checked = 0
+                alerts_triggered = 0
+                triggered_alerts = []
+
+                # Check narrative stats alerts (views, claims count, videos count)
+                stats_alerts = await alert_repo.check_narrative_stats_alerts(since)
+                for alert, narrative_id, current_value in stats_alerts:
+                    alerts_checked += 1
+                    
+                    # Record the trigger (will return None if already triggered)
+                    # Use the threshold as the unique key, not the actual value
+                    triggered = await alert_repo.record_alert_trigger(
+                        alert_id=alert.id,
+                        narrative_id=narrative_id,
+                        trigger_value=current_value,  # Store actual value for logging
+                        threshold_crossed=alert.threshold,  # Use threshold for uniqueness
+                        metadata={"alert_type": alert.alert_type.value},
+                    )
+                    
+                    if triggered:
+                        alerts_triggered += 1
+                        triggered_alerts.append((alert, triggered, narrative_id))
+
+                # Check topic alerts
+                topic_alerts = await alert_repo.check_topic_alerts(since)
+                for alert, narrative_id in topic_alerts:
+                    alerts_checked += 1
+                    
+                    # For topic alerts, we use narrative_id as the unique identifier
+                    # This ensures one alert per narrative-topic combination
+                    triggered = await alert_repo.record_alert_trigger(
+                        alert_id=alert.id,
+                        narrative_id=narrative_id,
+                        trigger_value=None,
+                        threshold_crossed=None,  # No threshold for topic alerts
+                        metadata={"alert_type": "topic", "topic_id": str(alert.topic_id)},
+                    )
+                    
+                    if triggered:
+                        alerts_triggered += 1
+                        triggered_alerts.append((alert, triggered, narrative_id))
+
+                # Check keyword alerts
+                keyword_alerts = await alert_repo.check_keyword_alerts(since)
+                for alert, narrative_id in keyword_alerts:
+                    alerts_checked += 1
+                    
+                    # For keyword alerts, we use narrative_id as the unique identifier
+                    # This ensures one alert per narrative-keyword combination
+                    triggered = await alert_repo.record_alert_trigger(
+                        alert_id=alert.id,
+                        narrative_id=narrative_id,
+                        trigger_value=None,
+                        threshold_crossed=None,  # No threshold for keyword alerts
+                        metadata={"alert_type": "keyword", "keyword": alert.keyword},
+                    )
+                    
+                    if triggered:
+                        alerts_triggered += 1
+                        triggered_alerts.append((alert, triggered, narrative_id))
+
+                # Send notifications
+                emails_sent = await self._send_alert_notifications(
+                    triggered_alerts, alert_repo, auth_repo, narrative_repo
+                )
+
+                # Record execution
+                execution = await alert_repo.record_execution(
+                    alerts_checked=alerts_checked,
+                    alerts_triggered=alerts_triggered,
+                    emails_sent=emails_sent,
+                    metadata={
+                        "since": since.isoformat(),
+                        "completed_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                )
+
+                return execution
+
+    async def _send_alert_notifications(
+        self, 
+        triggered_alerts: list[tuple[Alert, Any, UUID]],
+        alert_repo: AlertRepository,
+        auth_repo: AuthRepository,
+        narrative_repo: NarrativeRepository,
+    ) -> int:
+        """Send email notifications for triggered alerts."""
+        
+        user_alerts = defaultdict(list)
+        
+        for alert, triggered, narrative_id in triggered_alerts:
+            key = (alert.user_id, alert.organisation_id)
+            user_alerts[key].append((alert, triggered, narrative_id))
+
+        emails_sent = 0
+        
+        for (user_id, org_id), alerts in user_alerts.items():
+            user = await auth_repo.get_user_by_id(user_id)
+            org = await auth_repo.get_organisation_by_id(org_id)
+            
+            if not user or not org:
+                continue
+
+            alert_details = []
+            for alert, triggered, narrative_id in alerts:
+                narrative = await narrative_repo.get_narrative(narrative_id)
+                if narrative:
+                    alert_details.append({
+                        "alert_type": alert.alert_type.value,
+                        "narrative_title": narrative.title,
+                        "narrative_id": str(narrative_id),
+                        "trigger_value": triggered.trigger_value,
+                        "threshold": alert.threshold,
+                        "keyword": alert.keyword,
+                        "triggered_at": triggered.triggered_at,
+                    })
+
+            if alert_details:
+                subject, body = alerts_message(
+                    organisation_name=org.display_name,
+                    alerts=alert_details,
+                    locale=org.language,
+                )
+                
+                # Get emailer and send immediately (in CLI context)
+                # In API context, this could be done with BackgroundTask
+                emailer = await get_emailer()
+                emailer.send(
+                    to=user.email,
+                    subject=subject,
+                    html=body,
+                )
+                
+                emails_sent += 1
+                
+                for _, triggered, _ in alerts:
+                    await alert_repo.mark_notification_sent(triggered.id)
+
+        return emails_sent

--- a/core/app.py
+++ b/core/app.py
@@ -11,6 +11,7 @@ from psycopg.rows import DictRow, dict_row
 from psycopg_pool import AsyncConnectionPool
 
 from core import config, email
+from core.alerts.controller import AlertController
 from core.auth import dependencies, middleware
 from core.auth.controller import AuthController
 from core.auth.service import AuthService
@@ -21,7 +22,7 @@ from core.videos.claims.controller import ClaimController, RootClaimController
 from core.videos.controller import VideoController
 from core.videos.transcripts.controller import TranscriptController
 
-MIGRATION_TARGET_VERSION = 10
+MIGRATION_TARGET_VERSION = 11
 
 
 postgres_url = f"postgresql://{config.DB_USER}:{config.DB_PASSWORD}@{config.DB_HOST}:{config.DB_PORT}/{config.DB_NAME}"
@@ -80,6 +81,7 @@ api_router = Router(
     ],
     route_handlers=[
         AuthController,
+        AlertController,
         VideoController,
         TranscriptController,
         ClaimController,

--- a/core/email/messages.py
+++ b/core/email/messages.py
@@ -56,3 +56,54 @@ def password_reset_message(token: str, locale: str) -> tuple[str, str]:
     """
 
     return subject, body
+
+
+def alerts_message(
+    organisation_name: str, alerts: list[dict], locale: str
+) -> tuple[str, str]:
+    subject = f"Alert Summary for {organisation_name}"
+    
+    alert_items_html = ""
+    for alert in alerts:
+        alert_type = alert["alert_type"]
+        narrative_title = alert["narrative_title"]
+        
+        if alert_type == "narrative_views":
+            description = f"Narrative '{narrative_title}' reached {alert['trigger_value']:,} views (threshold: {alert['threshold']:,})"
+        elif alert_type == "narrative_claims_count":
+            description = f"Narrative '{narrative_title}' reached {alert['trigger_value']} claims (threshold: {alert['threshold']})"
+        elif alert_type == "narrative_videos_count":
+            description = f"Narrative '{narrative_title}' reached {alert['trigger_value']} videos (threshold: {alert['threshold']})"
+        elif alert_type == "narrative_with_topic":
+            description = f"New narrative '{narrative_title}' created with tracked topic"
+        elif alert_type == "keyword":
+            description = f"Narrative '{narrative_title}' contains keyword '{alert['keyword']}'"
+        else:
+            description = f"Alert triggered for narrative '{narrative_title}'"
+        
+        alert_items_html += f"""
+        <div style="background: white; border-left: 4px solid #00533D; margin: 1em 0; padding: 1em; text-align: left;">
+            <p style="margin: 0; font-weight: bold; color: #00533D;">{alert_type.replace('_', ' ').title()}</p>
+            <p style="margin: 0.5em 0 0 0; color: #666;">{description}</p>
+            <p style="margin: 0.5em 0 0 0;">
+                <a href="{config.APP_BASE_URL}/narratives/{alert['narrative_id']}" style="color: #00533D; text-decoration: underline;">
+                    View Narrative →
+                </a>
+            </p>
+        </div>
+        """
+    
+    body = f"""
+    <div style="{container_style}">
+        <h1 style="color: #333;">Alert Summary</h1>
+        <p style="margin: 1em 0; color: #666;">The following alerts have been triggered for {organisation_name}:</p>
+        <div style="margin: 2em 0;">
+            {alert_items_html}
+        </div>
+        <p style="margin: 2em 0 0 0; color: #999; font-size: 0.9em;">
+            To manage your alerts, visit your dashboard settings.
+        </p>
+    </div>
+    """
+    
+    return subject, body

--- a/core/email/messages.py
+++ b/core/email/messages.py
@@ -65,6 +65,7 @@ def alerts_message(
     
     alert_items_html = ""
     for alert in alerts:
+        alert_name = alert.get("alert_name", "Unnamed Alert")
         alert_type = alert["alert_type"]
         narrative_title = alert["narrative_title"]
         
@@ -83,8 +84,11 @@ def alerts_message(
         
         alert_items_html += f"""
         <div style="background: white; border-left: 4px solid #00533D; margin: 1em 0; padding: 1em; text-align: left;">
-            <p style="margin: 0; font-weight: bold; color: #00533D;">{alert_type.replace('_', ' ').title()}</p>
-            <p style="margin: 0.5em 0 0 0; color: #666;">{description}</p>
+            <h3 style="margin: 0 0 0.5em 0; color: #1F2937; font-size: 1.1em;">{alert_name}</h3>
+            <span style="display: inline-block; background: white; color: #333; border: 1px solid #333; padding: 2px 6px; border-radius: 3px; font-size: 0.7em; font-weight: 500; text-transform: uppercase;">
+                {alert_type.replace('_', ' ')}
+            </span>
+            <p style="margin: 0.75em 0 0 0; color: #666;">{description}</p>
             <p style="margin: 0.5em 0 0 0;">
                 <a href="{config.APP_BASE_URL}/narratives/{alert['narrative_id']}" style="color: #00533D; text-decoration: underline;">
                     View Narrative →

--- a/core/migrations/11.add-alerts-tables.up.sql
+++ b/core/migrations/11.add-alerts-tables.up.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS alerts (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     organisation_id uuid NOT NULL REFERENCES organisations(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
     alert_type alert_type NOT NULL,
     scope alert_scope NOT NULL,
     narrative_id uuid REFERENCES narratives(id) ON DELETE CASCADE,

--- a/core/migrations/11.add-alerts-tables.up.sql
+++ b/core/migrations/11.add-alerts-tables.up.sql
@@ -1,0 +1,85 @@
+BEGIN;
+
+CREATE TYPE alert_type AS ENUM (
+    'narrative_views',
+    'narrative_claims_count',
+    'narrative_videos_count',
+    'narrative_with_topic',
+    'keyword'
+);
+
+CREATE TYPE alert_scope AS ENUM (
+    'general',
+    'specific'
+);
+
+CREATE TABLE IF NOT EXISTS alerts (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    organisation_id uuid NOT NULL REFERENCES organisations(id) ON DELETE CASCADE,
+    alert_type alert_type NOT NULL,
+    scope alert_scope NOT NULL,
+    narrative_id uuid REFERENCES narratives(id) ON DELETE CASCADE,
+    threshold INTEGER,
+    topic_id uuid REFERENCES topics(id) ON DELETE CASCADE,
+    keyword TEXT,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    
+    CONSTRAINT valid_views_alert CHECK (
+        alert_type != 'narrative_views' OR threshold IS NOT NULL
+    ),
+    CONSTRAINT valid_claims_count_alert CHECK (
+        alert_type != 'narrative_claims_count' OR threshold IS NOT NULL
+    ),
+    CONSTRAINT valid_videos_count_alert CHECK (
+        alert_type != 'narrative_videos_count' OR threshold IS NOT NULL
+    ),
+    CONSTRAINT valid_topic_alert CHECK (
+        alert_type != 'narrative_with_topic' OR topic_id IS NOT NULL
+    ),
+    CONSTRAINT valid_keyword_alert CHECK (
+        alert_type != 'keyword' OR keyword IS NOT NULL
+    ),
+    CONSTRAINT valid_specific_alert CHECK (
+        scope != 'specific' OR narrative_id IS NOT NULL
+    ),
+    CONSTRAINT valid_general_alert CHECK (
+        scope != 'general' OR narrative_id IS NULL
+    )
+);
+
+CREATE TABLE IF NOT EXISTS alert_executions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    executed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    alerts_checked INTEGER NOT NULL DEFAULT 0,
+    alerts_triggered INTEGER NOT NULL DEFAULT 0,
+    emails_sent INTEGER NOT NULL DEFAULT 0,
+    metadata JSONB DEFAULT '{}'
+);
+
+CREATE TABLE IF NOT EXISTS alerts_triggered (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    alert_id uuid NOT NULL REFERENCES alerts(id) ON DELETE CASCADE,
+    narrative_id uuid NOT NULL REFERENCES narratives(id) ON DELETE CASCADE,
+    triggered_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    trigger_value INTEGER,
+    threshold_crossed INTEGER, -- The threshold that was crossed, in the future we may want to allow setting multiple thresholds
+    notification_sent BOOLEAN NOT NULL DEFAULT FALSE,
+    metadata JSONB DEFAULT '{}',
+    
+    UNIQUE(alert_id, narrative_id, threshold_crossed)
+);
+
+CREATE INDEX idx_alerts_user_org ON alerts(user_id, organisation_id);
+CREATE INDEX idx_alerts_type_enabled ON alerts(alert_type, enabled);
+CREATE INDEX idx_alerts_narrative ON alerts(narrative_id) WHERE narrative_id IS NOT NULL;
+CREATE INDEX idx_alerts_topic ON alerts(topic_id) WHERE topic_id IS NOT NULL;
+CREATE INDEX idx_alerts_keyword ON alerts(keyword) WHERE keyword IS NOT NULL;
+CREATE INDEX idx_alerts_triggered_alert ON alerts_triggered(alert_id);
+CREATE INDEX idx_alerts_triggered_narrative ON alerts_triggered(narrative_id);
+CREATE INDEX idx_alerts_triggered_at ON alerts_triggered(triggered_at);
+
+COMMIT;


### PR DESCRIPTION
This PR covers almost every request related to the alerts (we're still working on implementing Slack). It monitors narratives and sends email notifications when specific conditions are met. Users can create personalized alerts to track narrative metrics, topics, and keywords.

**We have two alert scopes:**

  - General: Monitors all narratives in the system
  - Specific: Monitors a single specified narrative

This allows setting a global alert for all narratives when they reach a specific number of views, but also monitor specific narratives individually.

**The alert types are:**

  1. Statistics-based Alerts

  - narrative_views: Triggers when total video views for a narrative exceed threshold
  - narrative_claims_count: Triggers when number of claims in a narrative exceed threshold
  - narrative_videos_count: Triggers when number of videos in a narrative exceed threshold

  2. Content-based Alerts

  - narrative_with_topic: Triggers when a new narrative is created with a specific topic
  - keyword: Triggers when a new narrative title or description contains a specific keyword

**Triggering Mechanism**

We have implemented a CLI command called `process-alerts` (`python -m core.cli process-alerts`), the idea is to run it periodically. We don't really know how many alerts we'll get the first days, so I'd run it each hour at the beginning. It tracks the last execution time to avoid duplicated alerts.

**Flow**

Only processes narratives that are:

  1. Created since the last alert check, OR
  2. Have videos updated since the last alert check

This prevents flooding users with alerts for historical data when first setting up an alert.

Deduplication

  - Each alert trigger is recorded with the specific threshold crossed
  - Prevents duplicate notifications for the same alert/narrative/threshold combination
  - Allows re-triggering if values increase beyond new thresholds

Email Notifications

  - Groups multiple triggered alerts into a single email per user
  - Includes alert name, type badge, and relevant narrative details
  - Handles email failures gracefully without stopping the alert processing

Database Schema

  - alerts table stores alert configurations
  - alert_executions tracks when alerts were processed
  - alert_triggered records individual alert triggers for deduplication