### PR TITLE
Stop using country codes in pastel inference

### DIFF
--- a/core/videos/controller.py
+++ b/core/videos/controller.py
@@ -29,7 +29,7 @@ from core.videos.models import (
     VideoFilters,
     VideoPatch,
 )
-from core.videos.pastel import COUNTRIES, KEYWORDS
+from core.videos.pastel import KEYWORDS
 from core.videos.service import VideoService
 from core.videos.transcripts.service import TranscriptService
 
@@ -90,7 +90,6 @@ async def extract_transcript_and_claims(
                     )
                     for s in sentences
                 ],
-                country_codes=COUNTRIES.get(org, []),
             )
 
             for claim in claims:
@@ -132,15 +131,17 @@ async def analyze_for_narratives(video: Video, video_claims: list[Claim]) -> Non
 
     claims_data = []
     for claim in video_claims:
-        claims_data.append({
-            "id": str(claim.id),
-            "claim": claim.claim,
-            "score": claim.metadata.get("score", 0),
-            "video_id": str(video.id),
-            "claim_api_url": urljoin(
-                APP_BASE_URL, "/api/videos/{video_id}/claims/{claim_id}"
-            ),
-        })
+        claims_data.append(
+            {
+                "id": str(claim.id),
+                "claim": claim.claim,
+                "score": claim.metadata.get("score", 0),
+                "video_id": str(video.id),
+                "claim_api_url": urljoin(
+                    APP_BASE_URL, "/api/videos/{video_id}/claims/{claim_id}"
+                ),
+            }
+        )
 
     payload = {
         "claims": claims_data,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ explicit = true
 
 [tool.uv.sources]
 torch = [{ index = "pytorch-cpu" }]
-harmful-claim-finder = { git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git" }
+harmful-claim-finder = { git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git" , branch = "make-country-codes-optional-in-pastel-pas-ai-1404"}
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "click>=8.1.0",
     "google-genai>=1.25.0",
     "httpx>=0.27.0",
-    "harmful-claim-finder>=0.1.0",
+    "harmful-claim-finder",
     "email-validator>=2.2.0",
     "google-genai>=1.25.0",
     "litestar[jwt,opentelemetry,pydantic,standard,structlog]>=2.16.0",
@@ -46,7 +46,7 @@ explicit = true
 
 [tool.uv.sources]
 torch = [{ index = "pytorch-cpu" }]
-harmful-claim-finder = { git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git"}
+harmful-claim-finder = { git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git", tag = "0.1.0" }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ explicit = true
 
 [tool.uv.sources]
 torch = [{ index = "pytorch-cpu" }]
-harmful-claim-finder = { git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git" , branch = "make-country-codes-optional-in-pastel-pas-ai-1404"}
+harmful-claim-finder = { git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git"}
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "click>=8.1.0",
     "google-genai>=1.25.0",
     "httpx>=0.27.0",
-    "harmful-claim-finder",
+    "harmful-claim-finder>=0.1.0",
     "email-validator>=2.2.0",
     "google-genai>=1.25.0",
     "litestar[jwt,opentelemetry,pydantic,standard,structlog]>=2.16.0",

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "google-genai", specifier = ">=1.25.0" },
-    { name = "harmful-claim-finder", git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git" },
+    { name = "harmful-claim-finder", git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git?tag=0.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "litestar", extras = ["jwt", "opentelemetry", "pydantic", "standard", "structlog"], specifier = ">=2.16.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.9" },
@@ -559,7 +559,7 @@ wheels = [
 [[package]]
 name = "harmful-claim-finder"
 version = "0.0.1"
-source = { git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git#87f3d9d3a54940594ec0ca2d93f99ec5ba227080" }
+source = { git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git?tag=0.1.0#87f3d9d3a54940594ec0ca2d93f99ec5ba227080" }
 dependencies = [
     { name = "google-cloud-storage" },
     { name = "google-genai" },

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "google-genai", specifier = ">=1.25.0" },
-    { name = "harmful-claim-finder", git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git" },
+    { name = "harmful-claim-finder", git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git?branch=make-country-codes-optional-in-pastel-pas-ai-1404" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "litestar", extras = ["jwt", "opentelemetry", "pydantic", "standard", "structlog"], specifier = ">=2.16.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.9" },
@@ -559,12 +559,11 @@ wheels = [
 [[package]]
 name = "harmful-claim-finder"
 version = "0.0.1"
-source = { git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git#ba7bc73a3fc396600ab5e58f279ac8a8e5ad377f" }
+source = { git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git?branch=make-country-codes-optional-in-pastel-pas-ai-1404#5d31c5493ceb77f5cb0eb4d96394fbac58a79aa3" }
 dependencies = [
     { name = "google-cloud-storage" },
     { name = "google-genai" },
     { name = "json-repair" },
-    { name = "pycountry" },
     { name = "pydantic" },
     { name = "pytest-asyncio" },
     { name = "python-dotenv" },
@@ -572,6 +571,7 @@ dependencies = [
     { name = "scipy" },
     { name = "scipy-stubs" },
     { name = "structlog" },
+    { name = "tenacity" },
     { name = "torch", version = "2.7.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.7.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "transformers" },
@@ -1323,15 +1323,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
-]
-
-[[package]]
-name = "pycountry"
-version = "24.6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/57/c389fa68c50590881a75b7883eeb3dc15e9e73a0fdc001cdd45c13290c92/pycountry-24.6.1.tar.gz", hash = "sha256:b61b3faccea67f87d10c1f2b0fc0be714409e8fcdcc1315613174f6466c10221", size = 6043910, upload-time = "2024-06-01T04:12:15.05Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/ec/1fb891d8a2660716aadb2143235481d15ed1cbfe3ad669194690b0604492/pycountry-24.6.1-py3-none-any.whl", hash = "sha256:f1a4fb391cd7214f8eefd39556d740adcc233c778a27f8942c8dca351d6ce06f", size = 6335189, upload-time = "2024-06-01T04:11:49.711Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "google-genai", specifier = ">=1.25.0" },
-    { name = "harmful-claim-finder", git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git?branch=make-country-codes-optional-in-pastel-pas-ai-1404" },
+    { name = "harmful-claim-finder", git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "litestar", extras = ["jwt", "opentelemetry", "pydantic", "standard", "structlog"], specifier = ">=2.16.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.9" },
@@ -559,7 +559,7 @@ wheels = [
 [[package]]
 name = "harmful-claim-finder"
 version = "0.0.1"
-source = { git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git?branch=make-country-codes-optional-in-pastel-pas-ai-1404#5d31c5493ceb77f5cb0eb4d96394fbac58a79aa3" }
+source = { git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git#87f3d9d3a54940594ec0ca2d93f99ec5ba227080" }
 dependencies = [
     { name = "google-cloud-storage" },
     { name = "google-genai" },


### PR DESCRIPTION
Fixes [#1421](https://linear.app/fullfact/issue/AI-1421/update-core-api-to-remove-country-codes).

Remove use of country codes from PASTEL inference in line with changes in [#21](https://github.com/Prebunking-at-Scale/harmful-claim-finder/pull/21) in the harmful-claim-finder.