### PR TITLE
feat: implement filters for narratives, claims and videos

### DIFF
--- a/core/narratives/controller.py
+++ b/core/narratives/controller.py
@@ -61,9 +61,11 @@ class NarrativeController(Controller):
         narrative_service: NarrativeService,
         limit: int = 100,
         offset: int = 0,
+        topic_id: UUID | None = None,
+        text: str | None = None,
     ) -> PaginatedJSON[list[Narrative]]:
         narratives, total = await narrative_service.get_all_narratives(
-            limit=limit, offset=offset
+            limit=limit, offset=offset, topic_id=topic_id, text=text
         )
         page = (offset // limit) + 1 if limit > 0 else 1
         return PaginatedJSON(

--- a/core/narratives/service.py
+++ b/core/narratives/service.py
@@ -36,11 +36,20 @@ class NarrativeService:
             return await repo.get_narratives_by_claim(claim_id)
 
     async def get_all_narratives(
-        self, limit: int = 100, offset: int = 0
+        self, 
+        limit: int = 100, 
+        offset: int = 0,
+        topic_id: UUID | None = None,
+        text: str | None = None
     ) -> tuple[list[Narrative], int]:
         async with self.repo() as repo:
-            narratives = await repo.get_all_narratives(limit=limit, offset=offset)
-            total = await repo.count_all_narratives()
+            narratives = await repo.get_all_narratives(
+                limit=limit, 
+                offset=offset, 
+                topic_id=topic_id, 
+                text=text
+            )
+            total = await repo.count_all_narratives(topic_id=topic_id, text=text)
             return narratives, total
 
     async def update_narrative(

--- a/core/videos/claims/controller.py
+++ b/core/videos/claims/controller.py
@@ -125,17 +125,18 @@ class RootClaimController(Controller):
 
     @get(
         path="/",
-        summary="Get all claims with optional topic filter",
+        summary="Get all claims with optional topic and text filters",
     )
     async def get_all_claims(
         self,
         claims_service: ClaimsService,
         topic_id: UUID | None = Parameter(None, query="topic_id"),
+        text: str | None = Parameter(None, query="text"),
         limit: int = Parameter(100, query="limit", gt=0, le=1000),
         offset: int = Parameter(0, query="offset", ge=0),
     ) -> PaginatedJSON[list[EnrichedClaim]]:
         claims, total = await claims_service.get_all_claims(
-            limit=limit, offset=offset, topic_id=topic_id
+            limit=limit, offset=offset, topic_id=topic_id, text=text
         )
         page = (offset // limit) + 1 if limit > 0 else 1
         return PaginatedJSON(

--- a/core/videos/claims/controller.py
+++ b/core/videos/claims/controller.py
@@ -125,18 +125,25 @@ class RootClaimController(Controller):
 
     @get(
         path="/",
-        summary="Get all claims with optional topic and text filters",
+        summary="Get all claims with optional topic, text, and score filters",
     )
     async def get_all_claims(
         self,
         claims_service: ClaimsService,
         topic_id: UUID | None = Parameter(None, query="topic_id"),
         text: str | None = Parameter(None, query="text"),
+        min_score: float | None = Parameter(None, query="min_score"),
+        max_score: float | None = Parameter(None, query="max_score"),
         limit: int = Parameter(100, query="limit", gt=0, le=1000),
         offset: int = Parameter(0, query="offset", ge=0),
     ) -> PaginatedJSON[list[EnrichedClaim]]:
         claims, total = await claims_service.get_all_claims(
-            limit=limit, offset=offset, topic_id=topic_id, text=text
+            limit=limit, 
+            offset=offset, 
+            topic_id=topic_id, 
+            text=text,
+            min_score=min_score,
+            max_score=max_score
         )
         page = (offset // limit) + 1 if limit > 0 else 1
         return PaginatedJSON(

--- a/core/videos/claims/repo.py
+++ b/core/videos/claims/repo.py
@@ -199,11 +199,13 @@ class ClaimRepository:
         limit: int = 100, 
         offset: int = 0, 
         topic_id: UUID | None = None,
-        text: str | None = None
+        text: str | None = None,
+        min_score: float | None = None,
+        max_score: float | None = None
     ) -> tuple[list[EnrichedClaim], int]:
         # Build the query conditionally
         where_conditions = []
-        params: dict[str, int | UUID | str] = {"limit": limit, "offset": offset}
+        params: dict[str, int | UUID | str | float] = {"limit": limit, "offset": offset}
 
         if topic_id:
             where_conditions.append("ct.topic_id = %(topic_id)s")
@@ -212,6 +214,14 @@ class ClaimRepository:
         if text:
             where_conditions.append("LOWER(c.claim) LIKE LOWER(%(text)s)")
             params["text"] = f"%{text}%"
+            
+        if min_score is not None:
+            where_conditions.append("(c.metadata->>'score')::float >= %(min_score)s")
+            params["min_score"] = min_score
+            
+        if max_score is not None:
+            where_conditions.append("(c.metadata->>'score')::float <= %(max_score)s")
+            params["max_score"] = max_score
             
         where_clause = "WHERE " + " AND ".join(where_conditions) if where_conditions else ""
 

--- a/core/videos/claims/service.py
+++ b/core/videos/claims/service.py
@@ -52,11 +52,15 @@ class ClaimsService:
             return await repo.get_claims_by_topic(topic_id, limit=limit, offset=offset)
 
     async def get_all_claims(
-        self, limit: int = 100, offset: int = 0, topic_id: UUID | None = None
+        self, 
+        limit: int = 100, 
+        offset: int = 0, 
+        topic_id: UUID | None = None,
+        text: str | None = None
     ) -> tuple[list[EnrichedClaim], int]:
         async with self.repo() as repo:
             return await repo.get_all_claims(
-                limit=limit, offset=offset, topic_id=topic_id
+                limit=limit, offset=offset, topic_id=topic_id, text=text
             )
 
     async def associate_topics_with_claim(

--- a/core/videos/claims/service.py
+++ b/core/videos/claims/service.py
@@ -56,11 +56,18 @@ class ClaimsService:
         limit: int = 100, 
         offset: int = 0, 
         topic_id: UUID | None = None,
-        text: str | None = None
+        text: str | None = None,
+        min_score: float | None = None,
+        max_score: float | None = None
     ) -> tuple[list[EnrichedClaim], int]:
         async with self.repo() as repo:
             return await repo.get_all_claims(
-                limit=limit, offset=offset, topic_id=topic_id, text=text
+                limit=limit, 
+                offset=offset, 
+                topic_id=topic_id, 
+                text=text,
+                min_score=min_score,
+                max_score=max_score
             )
 
     async def associate_topics_with_claim(

--- a/core/videos/controller.py
+++ b/core/videos/controller.py
@@ -208,8 +208,9 @@ class VideoController(Controller):
         video_service: VideoService,
         transcript_service: TranscriptService,
         claims_service: ClaimsService,
-        platform: list[str] | None = Parameter(None, query="platform"),
-        channel: list[str] | None = Parameter(None, query="channel"),
+        platform: str | None = Parameter(None, query="platform"),
+        channel: str | None = Parameter(None, query="channel"),
+        text: str | None = Parameter(None, query="text"),
         limit: int = Parameter(25, query="limit", gt=0, le=100),
         offset: int = Parameter(0, query="offset", ge=0),
     ) -> PaginatedJSON[list[AnalysedVideo]]:
@@ -218,6 +219,7 @@ class VideoController(Controller):
             offset=offset,
             platform=platform,
             channel=channel,
+            text=text,
         )
 
         # Fetch claims and narratives for each video

--- a/core/videos/repo.py
+++ b/core/videos/repo.py
@@ -175,19 +175,24 @@ class VideoRepository:
         self,
         limit: int,
         offset: int,
-        platform: list[str] | None = None,
-        channel: list[str] | None = None,
+        platform: str | None = None,
+        channel: str | None = None,
+        text: str | None = None,
     ) -> tuple[list[Video], int]:
         wheres = [sql.SQL("1=1")]
         params: dict[str, Any] = {"limit": limit, "offset": offset}
 
         if platform:
-            wheres.append(sql.SQL("platform = ANY(%(platform)s)"))
-            params["platform"] = platform
+            wheres.append(sql.SQL("LOWER(platform) LIKE LOWER(%(platform)s)"))
+            params["platform"] = f"%{platform}%"
 
         if channel:
-            wheres.append(sql.SQL("channel = ANY(%(channel)s)"))
-            params["channel"] = channel
+            wheres.append(sql.SQL("LOWER(channel) LIKE LOWER(%(channel)s)"))
+            params["channel"] = f"%{channel}%"
+            
+        if text:
+            wheres.append(sql.SQL("(LOWER(title) LIKE LOWER(%(text)s) OR LOWER(description) LIKE LOWER(%(text)s))"))
+            params["text"] = f"%{text}%"
 
         where_clause = sql.Composed(wheres).join(" AND ")
 

--- a/core/videos/service.py
+++ b/core/videos/service.py
@@ -42,13 +42,14 @@ class VideoService:
 
     async def get_videos_paginated(
         self,
-        limit: int,
-        offset: int,
-        platform: list[str] | None = None,
-        channel: list[str] | None = None,
+        limit: int = 100, 
+        offset: int = 0,
+        platform: str | None = None,
+        channel: str | None = None,
+        text: str | None = None,
     ) -> tuple[list[Video], int]:
         async with self.repo() as repo:
-            return await repo.get_videos_paginated(limit, offset, platform, channel)
+            return await repo.get_videos_paginated(limit, offset, platform, channel, text)
 
     async def get_narratives_for_video(self, video_id: UUID) -> list[Narrative]:
         async with self.repo() as repo:


### PR DESCRIPTION
This PR implements some filters that were originally implemented on the client side for the demo we made in July: text searches for narratives, claims and videos (both in title and description), channel filter in videos...