### PR TITLE
feat: update narrative if it already exists

### DIFF
--- a/core/narratives/repo.py
+++ b/core/narratives/repo.py
@@ -320,6 +320,23 @@ class NarrativeRepository:
             return False
         return row["count"] == len(claim_ids)
 
+    async def find_by_narrative_id_in_metadata(self, narrative_id: str) -> Narrative | None:
+        await self._session.execute(
+            """
+            SELECT * FROM narratives
+            WHERE metadata->>'narrative_id' = %(narrative_id)s
+            """,
+            {"narrative_id": narrative_id},
+        )
+        row = await self._session.fetchone()
+        if not row:
+            return None
+
+        claims = await self._get_narrative_claims(row["id"])
+        topics = await self._get_narrative_topics(row["id"])
+        videos = await self._get_narrative_videos(row["id"])
+        return Narrative(**row, claims=claims, topics=topics, videos=videos)
+
     async def get_narratives_by_topic(
         self, topic_id: UUID, limit: int = 100, offset: int = 0
     ) -> tuple[list[Narrative], int]:

--- a/core/narratives/service.py
+++ b/core/narratives/service.py
@@ -33,7 +33,7 @@ class NarrativeService:
                     existing_topic_ids = [topic.id for topic in existing_narrative.topics]
                     merged_topic_ids = list(set(existing_topic_ids + narrative.topic_ids))
                     
-                    return await repo.update_narrative(
+                    updated_narrative = await repo.update_narrative(
                         narrative_id=existing_narrative.id,
                         title=narrative.title,
                         description=narrative.description,
@@ -41,6 +41,9 @@ class NarrativeService:
                         topic_ids=merged_topic_ids,
                         metadata=narrative.metadata,
                     )
+                    if updated_narrative is None:
+                        raise ValueError(f"Failed to update narrative with ID {existing_narrative.id}")
+                    return updated_narrative
 
             return await repo.create_narrative(
                 title=narrative.title,

--- a/core/narratives/service.py
+++ b/core/narratives/service.py
@@ -19,6 +19,29 @@ class NarrativeService:
             if not await repo.claims_exist(narrative.claim_ids):
                 raise ValueError("one or more claims not found")
 
+            narrative_id_in_metadata = narrative.metadata.get("narrative_id")
+            if narrative_id_in_metadata:
+                existing_narrative = await repo.find_by_narrative_id_in_metadata(
+                    narrative_id_in_metadata
+                )
+                
+                if existing_narrative:
+                    # Merge claim_ids and topic_ids with existing ones
+                    existing_claim_ids = [claim.id for claim in existing_narrative.claims]
+                    merged_claim_ids = list(set(existing_claim_ids + narrative.claim_ids))
+                    
+                    existing_topic_ids = [topic.id for topic in existing_narrative.topics]
+                    merged_topic_ids = list(set(existing_topic_ids + narrative.topic_ids))
+                    
+                    return await repo.update_narrative(
+                        narrative_id=existing_narrative.id,
+                        title=narrative.title,
+                        description=narrative.description,
+                        claim_ids=merged_claim_ids,
+                        topic_ids=merged_topic_ids,
+                        metadata=narrative.metadata,
+                    )
+
             return await repo.create_narrative(
                 title=narrative.title,
                 description=narrative.description,


### PR DESCRIPTION
Inexplicably we were only creating narratives, not updating those we receive over and over again with new claims - this implements that. 