### PR TITLE
feat(auth): add ability to re-send invites

### DIFF
--- a/core/auth/service.py
+++ b/core/auth/service.py
@@ -161,6 +161,40 @@ class AuthService:
                 organisation_id=str(organisation_id),
             )
 
+    async def resend_invite_token(
+        self,
+        organisation_id: UUID,
+        email: str,
+    ) -> str | None:
+        async with self.repo() as repo:
+            organisation = await repo.get_organisation(organisation_id)
+            if organisation.deactivated is not None:
+                raise ConflictError("cannot resend invite to deactivated organisation")
+
+            email = email.strip()
+            user = await repo.get_user_by_email(email)
+            if not user:
+                raise ConflictError("cannot resend invite to non-existent user")
+
+            # Check if user has already accepted the invite
+            is_already_member = await repo.is_user_organisation_member(
+                user_id=user.id,
+                organisation_id=organisation_id,
+            )
+            if is_already_member:
+                raise ConflictError("user has already accepted the invite")
+
+            await repo.resend_invite(
+                user_id=user.id,
+                organisation_id=organisation_id,
+            )
+
+            return self.jwt_auth.create_token(
+                identifier=str(user.id),
+                token_expiration=INVITE_TTL,
+                organisation_id=str(organisation_id),
+            )
+
     async def accept_invite(self, token: str) -> LoginOptions:
         decoded = jwt.decode(
             token,


### PR DESCRIPTION
Adds an API endpoint to re-send invite tokens to users who have already been invited.