### PR TITLE
feat: allow super admins to to override their logged in organisation

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -28,7 +28,7 @@ MIGRATION_TARGET_VERSION = 11
 postgres_url = f"postgresql://{config.DB_USER}:{config.DB_PASSWORD}@{config.DB_HOST}:{config.DB_PORT}/{config.DB_NAME}"
 
 auth_service = AuthService()
-api_auth = middleware.APITokenAuthMiddleware(auth_service.jwt_auth)
+auth_middleware = middleware.AuthenticationMiddleware(auth_service.jwt_auth)
 
 
 def pool_factory(url: str) -> AsyncConnectionPool[AsyncConnection[DictRow]]:
@@ -104,8 +104,8 @@ app: Litestar = Litestar(
     debug=config.DEV_MODE,
     on_app_init=[
         auth_service.jwt_auth.on_app_init,
-        # Order is important so that api_auth can override jwt_auth's settings
-        api_auth.on_app_init,
+        # Order is important so that auth_middleware can override jwt_auth's settings
+        auth_middleware.on_app_init,
     ],
     route_handlers=[
         hello_world,

--- a/core/auth/controller.py
+++ b/core/auth/controller.py
@@ -20,6 +20,7 @@ from core.auth.models import (
     OrganisationInvite,
     OrganisationUpdateDTO,
     PasswordChange,
+    SuperAdminStatus,
     User,
     UserUpdateDTO,
 )
@@ -62,6 +63,7 @@ class AuthController(Controller):
         exclude_from_auth=True,
         tags=["auth"],
         raises=[NotAuthorizedError],
+        status_code=200,
     )
     async def login(self, auth_service: AuthService, data: Login) -> JSON[LoginOptions]:
         return JSON(
@@ -84,6 +86,7 @@ class AuthController(Controller):
         summary="Request an email to reset the users password",
         exclude_from_auth=True,
         tags=["auth"],
+        status_code=200,
     )
     async def password_reset(
         self,
@@ -220,6 +223,23 @@ class AuthController(Controller):
             organisation_id=organisation.id,
             user_id=user_id,
             is_admin=data.is_admin,
+        )
+
+    @patch(
+        path="/users/{user_id:uuid}/super-admin",
+        guards=[super_admin],
+        summary="Set the users super admin status",
+        tags=["users"],
+    )
+    async def set_super_admin_status(
+        self,
+        auth_service: AuthService,
+        user_id: UUID,
+        data: SuperAdminStatus,
+    ) -> None:
+        await auth_service.set_super_admin(
+            user_id=user_id,
+            is_super_admin=data.is_super_admin,
         )
 
     @post(

--- a/core/auth/middleware.py
+++ b/core/auth/middleware.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+import jwt
 from litestar.config.app import AppConfig
 from litestar.datastructures import URL, MutableScopeHeaders
 from litestar.exceptions import NotAuthorizedException
@@ -12,15 +13,20 @@ from core import config
 API_KEY_HEADER = "X-API-TOKEN"
 
 
-class APITokenAuthMiddleware(ASGIMiddleware):
-    """APITokenMiddleware intercepts any API keys, validates them, and creates a JWT
-    token for the given organisation which is injected into the request and used by
-    any handers"""
+class AuthenticationMiddleware(ASGIMiddleware):
+    """Authentication middleware that handles two authentication flows:
+
+    1. API Key Authentication: Validates API keys from X-API-TOKEN header and
+       creates JWT tokens for the specified organisation
+    2. Super Admin Override: Allows super admins to switch organisation context
+       via organisation_id query parameter by creating new JWT tokens with override flags
+    """
 
     exclude_opt_key = "no_api_key_auth"
 
-    def __init__(self, jwt_auth: JWTAuth):
+    def __init__(self, jwt_auth: JWTAuth, temp_token_lifetime=30):
         self.jwt_auth = jwt_auth
+        self.temp_token_lifetime = temp_token_lifetime
 
     def on_app_init(self, app_config: AppConfig) -> AppConfig:
         # Make sure to be the first middleware otherwise the jwt check
@@ -35,6 +41,8 @@ class APITokenAuthMiddleware(ASGIMiddleware):
         url = URL.from_scope(scope=scope)
         organisation_id = url.query_params.get("organisation_id", "")
         api_key = headers.get(API_KEY_HEADER)
+
+        # Handle API key authentication
         if api_key:
             if api_key not in config.VALID_API_KEYS:
                 raise NotAuthorizedException(
@@ -43,10 +51,32 @@ class APITokenAuthMiddleware(ASGIMiddleware):
 
             token = self.jwt_auth.create_token(
                 identifier="api-user",
-                token_expiration=timedelta(seconds=30),
+                token_expiration=timedelta(seconds=self.temp_token_lifetime),
                 is_api_user=True,
                 organisation_id=organisation_id,
             )
             headers["Authorization"] = "Bearer " + token
+
+        # Handle super admin organisation_id override
+        elif organisation_id:
+            auth_header = headers.get("Authorization")
+            if auth_header and auth_header.startswith("Bearer "):
+                try:
+                    token_str = auth_header[7:]
+                    decoded = jwt.decode(
+                        token_str,
+                        algorithms=[self.jwt_auth.algorithm],
+                        key=self.jwt_auth.token_secret,
+                    )
+
+                    new_token = self.jwt_auth.create_token(
+                        identifier=decoded["sub"],
+                        token_expiration=timedelta(seconds=self.temp_token_lifetime),
+                        is_super_admin_override=True,
+                        organisation_id=organisation_id,
+                    )
+                    headers["Authorization"] = "Bearer " + new_token
+                except (ValueError, KeyError, jwt.InvalidTokenError):
+                    pass
 
         await next_app(scope, receive, send)

--- a/core/auth/models.py
+++ b/core/auth/models.py
@@ -50,6 +50,7 @@ class AuthToken(Token):
     is_api_user: bool = False
     is_password_reset: bool = False
     organisation_id: str | None = None
+    is_super_admin_override: bool = False
 
 
 class OrganisationInvite(BaseModel):
@@ -71,6 +72,10 @@ class PasswordChange(BaseModel):
 
 class AdminStatus(BaseModel):
     is_admin: bool
+
+
+class SuperAdminStatus(BaseModel):
+    is_super_admin: bool
 
 
 class OrganisationToken(BaseModel):

--- a/core/auth/repo.py
+++ b/core/auth/repo.py
@@ -293,6 +293,22 @@ class AuthRepository:
         if not self._session.rowcount:
             raise NotFoundError("user not found")
 
+    async def set_super_admin(self, user_id: UUID, is_super_admin: bool):
+        await self._session.execute(
+            """
+            UPDATE users SET
+                is_super_admin = %(is_super_admin)s,
+                updated_at = now()
+            WHERE id = %(user_id)s
+            """,
+            {
+                "user_id": user_id,
+                "is_super_admin": is_super_admin,
+            },
+        )
+        if not self._session.rowcount:
+            raise NotFoundError("user not found")
+
     async def organisation_and_role(
         self, user_id: UUID, organisation_id: UUID
     ) -> tuple[Organisation, bool]:

--- a/core/auth/service.py
+++ b/core/auth/service.py
@@ -56,6 +56,12 @@ class AuthService:
             organisation, is_admin = None, False
             if token.organisation_id:
                 organisation_id = UUID(hex=token.organisation_id)
+
+                if token.is_super_admin_override and not user.is_super_admin:
+                    raise NotAuthorizedError(
+                        "organisation_id override requires super admin privileges"
+                    )
+
                 organisation, is_admin = await repo.organisation_and_role(
                     user.id, organisation_id
                 )
@@ -213,6 +219,10 @@ class AuthService:
     ) -> None:
         async with self.repo() as repo:
             await repo.set_admin(user_id, organisation_id, is_admin)
+
+    async def set_super_admin(self, user_id: UUID, is_super_admin: bool) -> None:
+        async with self.repo() as repo:
+            await repo.set_super_admin(user_id, is_super_admin)
 
     async def password_reset_token(self, email: str) -> str | None:
         async with self.repo() as repo:

--- a/tests/auth/controller_test.py
+++ b/tests/auth/controller_test.py
@@ -1,0 +1,663 @@
+from collections.abc import AsyncIterator
+
+from litestar import Litestar
+from litestar.testing import AsyncTestClient
+from pytest import fixture
+from testing.postgresql import Postgresql
+
+import core.app as app
+from core.auth.models import (
+    AdminStatus,
+    Organisation,
+    OrganisationInvite,
+    SuperAdminStatus,
+    User,
+)
+from core.auth.service import AuthService
+from tests.auth.conftest import OrganisationFactory, UserFactory, create_user
+
+
+def get_access_token(login_options) -> str:
+    """Helper to extract access token from login options"""
+    return list(login_options.organisations.values())[0].token
+
+
+async def create_user_with_password(
+    auth_service: AuthService,
+    organisation: Organisation,
+    as_admin: bool = False,
+    email: str | None = None,
+    password: str = "password123456",
+    is_super_admin: bool = False,
+    **kwargs,
+) -> tuple[User, str]:
+    if email is None:
+        user_factory = UserFactory.build(is_super_admin=is_super_admin, **kwargs)
+        email = user_factory.email
+
+    invite_token = await auth_service.invite_token(
+        organisation_id=organisation.id,
+        email=email,
+        as_admin=as_admin,
+        auto_accept=False,
+    )
+    assert invite_token is not None
+
+    login_options = await auth_service.accept_invite(invite_token)
+    user = login_options.user
+
+    if is_super_admin:
+        await auth_service.set_super_admin(user.id, True)
+        user = await auth_service.get_user_by_email(user.email)
+        assert user is not None
+
+    await auth_service.update_password(user, password, None)
+    return user, password
+
+
+@fixture(scope="function")
+async def auth_client(
+    temp_db: Postgresql,
+) -> AsyncIterator[AsyncTestClient[Litestar]]:
+    app.postgres_url = temp_db.url()
+    async with AsyncTestClient(app=app.app) as client:
+        yield client
+
+
+async def test_login_success(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, password = await create_user_with_password(
+        auth_service, organisation, email="test@example.com"
+    )
+
+    response = await auth_client.post(
+        "/api/auth/login",
+        json={"email": user.email, "password": password},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert "organisations" in data
+    assert data["user"]["email"] == user.email
+
+
+async def test_login_invalid_credentials(
+    auth_client: AsyncTestClient[Litestar],
+) -> None:
+    response = await auth_client.post(
+        "/api/auth/login",
+        json={"email": "nonexistent@example.com", "password": "wrongpassword123"},
+    )
+    assert response.status_code == 401
+
+
+async def test_get_identity(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, password = await create_user_with_password(auth_service, organisation)
+    login_options = await auth_service.login(user.email, password)
+
+    response = await auth_client.get(
+        "/api/auth/identity",
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["user"]["email"] == user.email
+    assert data["organisation"]["id"] == str(organisation.id)
+
+
+async def test_password_reset_request(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, _ = await create_user_with_password(auth_service, organisation)
+
+    response = await auth_client.post(
+        "/api/auth/request-password-reset",
+        params={"email": user.email, "locale": "en"},
+    )
+
+    assert response.status_code == 200
+
+
+async def test_password_reset_request_nonexistent_user(
+    auth_client: AsyncTestClient[Litestar],
+) -> None:
+    response = await auth_client.post(
+        "/api/auth/request-password-reset",
+        params={"email": "nonexistent@example.com"},
+    )
+
+    assert response.status_code == 200
+
+
+async def test_password_update(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, password = await create_user_with_password(auth_service, organisation)
+    login_options = await auth_service.login(user.email, password)
+
+    response = await auth_client.patch(
+        "/api/auth/user/password",
+        json={"new_password": "newpassword123456"},
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 200
+
+
+async def test_get_user(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, password = await create_user_with_password(auth_service, organisation)
+    login_options = await auth_service.login(user.email, password)
+
+    response = await auth_client.get(
+        "/api/auth/user",
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["email"] == user.email
+
+
+async def test_update_user(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, password = await create_user_with_password(auth_service, organisation)
+    login_options = await auth_service.login(user.email, password)
+
+    update_data = {"display_name": "Updated Name"}
+
+    response = await auth_client.patch(
+        "/api/auth/user",
+        json=update_data,
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["display_name"] == "Updated Name"
+
+
+async def test_create_organisation_as_super_admin(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    super_admin, password = await create_user_with_password(
+        auth_service, organisation, is_super_admin=True
+    )
+    login_options = await auth_service.login(super_admin.email, password)
+
+    new_org = OrganisationFactory.build()
+
+    response = await auth_client.post(
+        "/api/auth/organisation",
+        json=new_org.model_dump(mode="json"),
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 201
+    data = response.json()["data"]
+    assert data["display_name"] == new_org.display_name
+
+
+async def test_create_organisation_as_org_admin_fails(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    org_admin, password = await create_user_with_password(
+        auth_service, organisation, as_admin=True
+    )
+    login_options = await auth_service.login(org_admin.email, password)
+
+    new_org = OrganisationFactory.build()
+
+    response = await auth_client.post(
+        "/api/auth/organisation",
+        json=new_org.model_dump(mode="json"),
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 401
+
+
+async def test_create_organisation_as_regular_user_fails(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, password = await create_user_with_password(auth_service, organisation)
+    login_options = await auth_service.login(user.email, password)
+
+    new_org = OrganisationFactory.build()
+
+    response = await auth_client.post(
+        "/api/auth/organisation",
+        json=new_org.model_dump(mode="json"),
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 401
+
+
+async def test_update_organisation_as_admin(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    admin, password = await create_user_with_password(
+        auth_service, organisation, as_admin=True
+    )
+    login_options = await auth_service.login(admin.email, password)
+
+    update_data = {"display_name": "Updated Organisation Name"}
+
+    response = await auth_client.patch(
+        "/api/auth/organisation",
+        json=update_data,
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["display_name"] == "Updated Organisation Name"
+
+
+async def test_update_organisation_as_regular_user_fails(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, password = await create_user_with_password(auth_service, organisation)
+    login_options = await auth_service.login(user.email, password)
+
+    update_data = {"display_name": "Updated Organisation Name"}
+
+    response = await auth_client.patch(
+        "/api/auth/organisation",
+        json=update_data,
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 401
+
+
+async def test_get_organisation(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, password = await create_user_with_password(auth_service, organisation)
+    login_options = await auth_service.login(user.email, password)
+
+    response = await auth_client.get(
+        "/api/auth/organisation",
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["id"] == str(organisation.id)
+
+
+async def test_remove_user_as_admin(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    admin, password = await create_user_with_password(
+        auth_service, organisation, as_admin=True
+    )
+    user_to_remove = await create_user(auth_service, organisation, False)
+    login_options = await auth_service.login(admin.email, password)
+
+    response = await auth_client.delete(
+        f"/api/auth/organisation/users/{user_to_remove.id}",
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 204
+
+
+async def test_remove_user_as_regular_user_fails(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, password = await create_user_with_password(auth_service, organisation)
+    user_to_remove = await create_user(auth_service, organisation, False)
+    login_options = await auth_service.login(user.email, password)
+
+    response = await auth_client.delete(
+        f"/api/auth/organisation/users/{user_to_remove.id}",
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 401
+
+
+async def test_set_admin_status_as_admin(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    admin, password = await create_user_with_password(
+        auth_service, organisation, as_admin=True
+    )
+    user = await create_user(auth_service, organisation, False)
+    login_options = await auth_service.login(admin.email, password)
+
+    admin_status = AdminStatus(is_admin=True)
+
+    response = await auth_client.patch(
+        f"/api/auth/organisation/users/{user.id}/admin",
+        json=admin_status.model_dump(mode="json"),
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 200
+
+
+async def test_set_admin_status_as_regular_user_fails(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, password = await create_user_with_password(auth_service, organisation)
+    target_user = await create_user(auth_service, organisation, False)
+    login_options = await auth_service.login(user.email, password)
+
+    admin_status = AdminStatus(is_admin=True)
+
+    response = await auth_client.patch(
+        f"/api/auth/organisation/users/{target_user.id}/admin",
+        json=admin_status.model_dump(mode="json"),
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 401
+
+
+async def test_set_super_admin_status_as_super_admin(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    super_admin, password = await create_user_with_password(
+        auth_service, organisation, is_super_admin=True
+    )
+    target_user = await create_user(auth_service, organisation, False)
+    login_options = await auth_service.login(super_admin.email, password)
+
+    # First set the user as super admin using the service method directly
+    await auth_service.set_super_admin(super_admin.id, True)
+
+    super_admin_status = SuperAdminStatus(is_super_admin=True)
+
+    response = await auth_client.patch(
+        f"/api/auth/users/{target_user.id}/super-admin",
+        json=super_admin_status.model_dump(mode="json"),
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 200
+
+
+async def test_set_super_admin_status_as_regular_user_fails(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, password = await create_user_with_password(auth_service, organisation)
+    target_user = await create_user(auth_service, organisation, False)
+    login_options = await auth_service.login(user.email, password)
+
+    super_admin_status = SuperAdminStatus(is_super_admin=True)
+
+    response = await auth_client.patch(
+        f"/api/auth/users/{target_user.id}/super-admin",
+        json=super_admin_status.model_dump(mode="json"),
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 401
+
+
+async def test_invite_user_as_admin(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    admin, password = await create_user_with_password(
+        auth_service, organisation, as_admin=True
+    )
+    login_options = await auth_service.login(admin.email, password)
+
+    invite_data = OrganisationInvite(user_email="newuser@example.com", as_admin=False)
+
+    response = await auth_client.post(
+        "/api/auth/organisation/invite",
+        json=invite_data.model_dump(mode="json"),
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+
+    assert response.status_code == 201
+
+
+async def test_invite_user_as_regular_user_fails(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, password = await create_user_with_password(auth_service, organisation)
+    login_options = await auth_service.login(user.email, password)
+
+    invite_data = OrganisationInvite(user_email="newuser@example.com", as_admin=False)
+
+    response = await auth_client.post(
+        "/api/auth/organisation/invite",
+        json=invite_data.model_dump(mode="json"),
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 401
+
+
+async def test_join_organisation_with_valid_token(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    _ = await create_user_with_password(auth_service, organisation, as_admin=True)
+    invite_token = await auth_service.invite_token(
+        organisation_id=organisation.id,
+        email="newuser@example.com",
+        as_admin=False,
+        auto_accept=False,
+    )
+    assert invite_token is not None
+
+    response = await auth_client.get(
+        "/api/auth/organisation/invite/accept",
+        params={"invite_token": invite_token},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert "organisations" in data
+
+
+async def test_join_organisation_with_invalid_token(
+    auth_client: AsyncTestClient[Litestar],
+) -> None:
+    response = await auth_client.get(
+        "/api/auth/organisation/invite/accept",
+        params={"invite_token": "invalid_token"},
+    )
+    assert response.status_code == 500
+
+
+async def test_organisation_users(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    user, password = await create_user_with_password(auth_service, organisation)
+    admin = await create_user(auth_service, organisation, True)
+    login_options = await auth_service.login(user.email, password)
+
+    response = await auth_client.get(
+        "/api/auth/organisation/users",
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 2
+    user_emails = {user_data["email"] for user_data in data}
+    assert user.email in user_emails
+    assert admin.email in user_emails
+
+
+# Tests for super admin organisation override functionality
+
+
+async def test_super_admin_organisation_override_success(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    """Test that super admin can switch organisation context using organisation_id parameter"""
+    other_org = await auth_service.create_organisation(OrganisationFactory.build())
+
+    super_admin, password = await create_user_with_password(
+        auth_service, organisation, is_super_admin=True
+    )
+    login_options = await auth_service.login(super_admin.email, password)
+    token = get_access_token(login_options)
+
+    response = await auth_client.get(
+        f"/api/auth/identity?organisation_id={other_org.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["user"]["email"] == super_admin.email
+    assert data["organisation"]["id"] == str(other_org.id)
+    assert data["is_organisation_admin"] is True
+
+
+async def test_regular_user_organisation_override_fails(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    """Test that regular users cannot use organisation override even with valid UUID"""
+    other_org = await auth_service.create_organisation(OrganisationFactory.build())
+
+    user, password = await create_user_with_password(auth_service, organisation)
+    login_options = await auth_service.login(user.email, password)
+    token = get_access_token(login_options)
+
+    response = await auth_client.get(
+        f"/api/auth/identity?organisation_id={other_org.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+
+
+async def test_organisation_admin_override_fails(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    """Test that organisation admins cannot override to different organisations"""
+    other_org = await auth_service.create_organisation(OrganisationFactory.build())
+
+    org_admin, password = await create_user_with_password(
+        auth_service, organisation, as_admin=True
+    )
+    login_options = await auth_service.login(org_admin.email, password)
+    token = get_access_token(login_options)
+
+    response = await auth_client.get(
+        f"/api/auth/identity?organisation_id={other_org.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+
+
+async def test_super_admin_override_with_deactivated_organisation_fails(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    """Test that super admin cannot override to deactivated organisation"""
+    other_org = await auth_service.create_organisation(OrganisationFactory.build())
+    await auth_service.deactivate_organisation(other_org.id)
+
+    super_admin, password = await create_user_with_password(
+        auth_service, organisation, is_super_admin=True
+    )
+    login_options = await auth_service.login(super_admin.email, password)
+    token = get_access_token(login_options)
+
+    response = await auth_client.get(
+        f"/api/auth/identity?organisation_id={other_org.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+
+
+async def test_super_admin_override_with_nonexistent_organisation_fails(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    """Test that super admin cannot override to non-existent organisation"""
+    from uuid import uuid4
+
+    super_admin, password = await create_user_with_password(
+        auth_service, organisation, is_super_admin=True
+    )
+    login_options = await auth_service.login(super_admin.email, password)
+    token = get_access_token(login_options)
+
+    fake_org_id = uuid4()
+    response = await auth_client.get(
+        f"/api/auth/identity?organisation_id={fake_org_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+
+
+async def test_super_admin_override_preserves_functionality(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    """Test that super admin can perform admin actions in overridden organisation context"""
+    other_org = await auth_service.create_organisation(OrganisationFactory.build())
+    other_user = await create_user(auth_service, other_org, False)
+
+    super_admin, password = await create_user_with_password(
+        auth_service, organisation, is_super_admin=True
+    )
+    login_options = await auth_service.login(super_admin.email, password)
+    token = get_access_token(login_options)
+
+    update_data = {"display_name": "Updated by Super Admin"}
+    response = await auth_client.patch(
+        f"/api/auth/organisation?organisation_id={other_org.id}",
+        json=update_data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["display_name"] == "Updated by Super Admin"
+
+    admin_status = AdminStatus(is_admin=True)
+    response = await auth_client.patch(
+        f"/api/auth/organisation/users/{other_user.id}/admin?organisation_id={other_org.id}",
+        json=admin_status.model_dump(mode="json"),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200


### PR DESCRIPTION
This PR adds the following:
 - The ability for super admins to override / impersonate an organisation using the `organisation_id` query param, similar to API keys
 - Adds new handlers to promote users to super admin status
 - Lots of tests