### PR TITLE
Add language detection for transcripts

### DIFF
--- a/core/analysis/language_id.py
+++ b/core/analysis/language_id.py
@@ -1,0 +1,20 @@
+import langid
+
+
+def predict_language(text: str) -> str:
+    """
+    Predicts the main language of a given piece of text.
+
+    Parameters
+        ----------
+        text : str
+            Some text
+
+        Returns
+        -------
+        str
+            The predicted two letter language code.
+            For example, "en" for English or "ar" for Arabic.
+    """
+    predictions = langid.classify(text)
+    return predictions[0]

--- a/core/videos/controller.py
+++ b/core/videos/controller.py
@@ -16,7 +16,7 @@ from litestar.dto import DTOData
 from litestar.exceptions import NotFoundException
 from litestar.params import Parameter
 
-from core.analysis import genai
+from core.analysis import genai, language_id
 from core.config import APP_BASE_URL, NARRATIVES_API_KEY, NARRATIVES_BASE_URL
 from core.errors import ConflictError
 from core.models import Claim, Transcript, TranscriptSentence, Video
@@ -64,6 +64,8 @@ async def extract_transcript_and_claims(
 
     result = await genai.generate_transcript(video.source_url)
     sentences = [TranscriptSentence(**x.model_dump()) for x in result]
+    for sentence in sentences:
+        sentence.metadata["language"] = language_id.predict_language(sentence.text)
 
     if sentences:
         transcript = Transcript(video_id=video.id, sentences=sentences)

--- a/core/videos/service.py
+++ b/core/videos/service.py
@@ -28,12 +28,17 @@ class VideoService:
         async with self.repo() as repo:
             return await repo.add_video(video)
 
-    async def patch_video(self, video_id: UUID, video_data: DTOData[Video]) -> Video:
+    async def patch_video(
+        self, video_id: UUID, video_data: DTOData[Video] | Video
+    ) -> Video:
         async with self.repo() as repo:
             video = await repo.get_video_by_id(video_id)
             if not video:
                 raise ValueError(f"Video with ID {video_id} not found")
-            updated_video = video_data.update_instance(video)
+            if isinstance(video_data, DTOData):
+                updated_video = video_data.update_instance(video)
+            else:
+                updated_video = video_data
             return await repo.update_video(updated_video)
 
     async def delete_video(self, video_id) -> None:
@@ -42,14 +47,16 @@ class VideoService:
 
     async def get_videos_paginated(
         self,
-        limit: int = 100, 
+        limit: int = 100,
         offset: int = 0,
         platform: str | None = None,
         channel: str | None = None,
         text: str | None = None,
     ) -> tuple[list[Video], int]:
         async with self.repo() as repo:
-            return await repo.get_videos_paginated(limit, offset, platform, channel, text)
+            return await repo.get_videos_paginated(
+                limit, offset, platform, channel, text
+            )
 
     async def get_narratives_for_video(self, video_id: UUID) -> list[Narrative]:
         async with self.repo() as repo:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "torch>=2.7.1",
     "bcrypt>=4.3.0",
     "python-i18n>=0.3.9",
+    "langid>=1.1.6",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,7 @@ follow_untyped_imports = true
 [[tool.mypy.overrides]]
 module = ["i18n.*"]
 follow_untyped_imports = true
+
+[[tool.mypy.overrides]]
+module = ["langid.*"]
+follow_untyped_imports = true

--- a/uv.lock
+++ b/uv.lock
@@ -199,6 +199,7 @@ dependencies = [
     { name = "google-genai" },
     { name = "harmful-claim-finder" },
     { name = "httpx" },
+    { name = "langid" },
     { name = "litestar", extra = ["jwt", "opentelemetry", "pydantic", "standard", "structlog"] },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "python-i18n" },
@@ -228,6 +229,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.25.0" },
     { name = "harmful-claim-finder", git = "https://github.com/Prebunking-at-Scale/harmful-claim-finder.git?tag=0.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "langid", specifier = ">=1.1.6" },
     { name = "litestar", extras = ["jwt", "opentelemetry", "pydantic", "standard", "structlog"], specifier = ">=2.16.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.9" },
     { name = "python-i18n", specifier = ">=0.3.9" },
@@ -735,6 +737,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/88/36/e03fe9da84e04b475
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/e1/f0e63cc027669763ccc2c1e62ba69959ec02db5328c81df2508a52711ec9/json_repair-0.40.0-py3-none-any.whl", hash = "sha256:46955bfd22338ba60cc5239c0b01462ba419871b19fcd68d8881aca4fa3b0d2f", size = 20736, upload-time = "2025-03-19T12:21:42.867Z" },
 ]
+
+[[package]]
+name = "langid"
+version = "1.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/4c/0fb7d900d3b0b9c8703be316fbddffecdab23c64e1b46c7a83561d78bd43/langid-1.1.6.tar.gz", hash = "sha256:044bcae1912dab85c33d8e98f2811b8f4ff1213e5e9a9e9510137b84da2cb293", size = 1925978, upload-time = "2016-04-05T22:34:15.786Z" }
 
 [[package]]
 name = "litestar"


### PR DESCRIPTION
Adds basic language detection for transcripts.

Adds an overall prediction to the video metadata, and individual sentence predictions in the sentence metadata.

This is because sentence predictions are often innacurate: the sentences we get are often one or two words, and a lot of languages share words. For example, in a Spanish transcript I was looking at, some short sentences were being confused as Galician.

The overall prediction is more accurate, but at the cost of picking up on things like code switching.