### PR TITLE
feat: return invited but not accepted users

### DIFF
--- a/core/auth/controller.py
+++ b/core/auth/controller.py
@@ -19,6 +19,7 @@ from core.auth.models import (
     OrganisationCreateDTO,
     OrganisationInvite,
     OrganisationUpdateDTO,
+    OrganisationUser,
     PasswordChange,
     SuperAdminStatus,
     User,
@@ -330,5 +331,5 @@ class AuthController(Controller):
         self,
         auth_service: AuthService,
         organisation: Organisation,
-    ) -> JSON[list[User]]:
+    ) -> JSON[list[OrganisationUser]]:
         return JSON(await auth_service.organisation_users(organisation.id))

--- a/core/auth/models.py
+++ b/core/auth/models.py
@@ -34,6 +34,14 @@ class User(BaseModel):
     is_super_admin: bool = False
 
 
+class OrganisationUser(User):
+    """User with their organisation membership status"""
+
+    invited: datetime | None = None
+    accepted: datetime | None = None
+    is_admin: bool = False
+
+
 class Identity(BaseModel):
     """An identity and roles associated with a specific request. This should
     be used to perform authorization checks for requests that require one"""

--- a/core/auth/repo.py
+++ b/core/auth/repo.py
@@ -4,7 +4,7 @@ from uuid import UUID
 import psycopg
 from psycopg.rows import DictRow
 
-from core.auth.models import Organisation, User
+from core.auth.models import Organisation, OrganisationUser, User
 from core.errors import (
     ConflictError,
     InvalidInviteError,
@@ -385,7 +385,7 @@ class AuthRepository:
     async def organisation_users(
         self,
         organisation_id: UUID,
-    ) -> list[User]:
+    ) -> list[OrganisationUser]:
         await self._session.execute(
             """
                 SELECT *
@@ -394,14 +394,13 @@ class AuthRepository:
                 WHERE
                     ou.organisation_id = %(organisation_id)s
                     AND ou.deactivated IS NULL
-                    AND ou.accepted IS NOT NULL
             """,
             {
                 "organisation_id": organisation_id,
             },
         )
 
-        return [User(**row) for row in await self._session.fetchall()]
+        return [OrganisationUser(**row) for row in await self._session.fetchall()]
 
     async def is_user_organisation_member(
         self, user_id: UUID, organisation_id: UUID

--- a/core/auth/service.py
+++ b/core/auth/service.py
@@ -15,6 +15,7 @@ from core.auth.models import (
     LoginOptions,
     Organisation,
     OrganisationToken,
+    OrganisationUser,
     User,
 )
 from core.auth.repo import AuthRepository
@@ -129,7 +130,7 @@ class AuthService:
         async with self.repo() as repo:
             await repo.deactivate_organisation(organisation_id)
 
-    async def organisation_users(self, organisation_id: UUID) -> list[User]:
+    async def organisation_users(self, organisation_id: UUID) -> list[OrganisationUser]:
         async with self.repo() as repo:
             return await repo.organisation_users(organisation_id)
 

--- a/tests/auth/controller_test.py
+++ b/tests/auth/controller_test.py
@@ -539,6 +539,48 @@ async def test_organisation_users(
     assert invited_user_data["accepted"] is None
 
 
+async def test_organisation_users_admin_status(
+    auth_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+) -> None:
+    # Create regular user
+    regular_user, password = await create_user_with_password(auth_service, organisation)
+
+    # Create admin user
+    admin_user = await create_user(auth_service, organisation, True)
+
+    # Create invited admin user who hasn't accepted yet
+    invite_token = await auth_service.invite_token(
+        organisation_id=organisation.id,
+        email="invitedadmin@example.com",
+        as_admin=True,
+        auto_accept=False,
+    )
+    assert invite_token is not None
+
+    login_options = await auth_service.login(regular_user.email, password)
+
+    response = await auth_client.get(
+        "/api/auth/organisation/users",
+        headers={"Authorization": f"Bearer {get_access_token(login_options)}"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 3
+
+    user_data_by_email = {user_data["email"]: user_data for user_data in data}
+
+    # Regular user should not be admin
+    assert user_data_by_email[regular_user.email]["is_admin"] is False
+
+    # Admin user should be admin
+    assert user_data_by_email[admin_user.email]["is_admin"] is True
+
+    # Invited admin user should be admin even though not accepted yet
+    assert user_data_by_email["invitedadmin@example.com"]["is_admin"] is True
+
+
 # Tests for super admin organisation override functionality
 
 


### PR DESCRIPTION
Includes users who have been invited but not yet accepted an invite to an organisations in the existing organisation/users endpoint.

It also includes details about admin status and invite times.