### PR TITLE
feat: add endpoint to list all organisations

### DIFF
--- a/core/auth/controller.py
+++ b/core/auth/controller.py
@@ -333,3 +333,15 @@ class AuthController(Controller):
         organisation: Organisation,
     ) -> JSON[list[OrganisationUser]]:
         return JSON(await auth_service.organisation_users(organisation.id))
+
+    @get(
+        path="/organisations",
+        guards=[super_admin],
+        summary="List all organisations",
+        tags=["organisations"],
+    )
+    async def list_organisations(
+        self,
+        auth_service: AuthService,
+    ) -> JSON[list[Organisation]]:
+        return JSON(await auth_service.get_all_organisations())

--- a/core/auth/repo.py
+++ b/core/auth/repo.py
@@ -439,3 +439,14 @@ class AuthRepository:
         )
         if not self._session.rowcount:
             raise ConflictError("no pending invite found for this user")
+
+    async def get_all_organisations(self) -> list[Organisation]:
+        """Get all active organisations"""
+        await self._session.execute(
+            """
+            SELECT * FROM organisations
+            WHERE deactivated IS NULL
+            ORDER BY created_at DESC
+            """
+        )
+        return [Organisation(**row) for row in await self._session.fetchall()]

--- a/core/auth/service.py
+++ b/core/auth/service.py
@@ -280,3 +280,7 @@ class AuthService:
         async with self.repo() as repo:
             hash = self._password_hash(new_password)
             await repo.update_password_hash(user.id, hash, last_update_before)
+
+    async def get_all_organisations(self) -> list[Organisation]:
+        async with self.repo() as repo:
+            return await repo.get_all_organisations()


### PR DESCRIPTION
Very basic `GET /api/auth/organisations` API endpoint so we can put something on this page
<img width="1168" height="350" alt="image" src="https://github.com/user-attachments/assets/4a6231f1-d24c-447e-90d1-da1aa85f9859" />
