### PR TITLE
feat: add ability to login using a "magic link" sent via email

### DIFF
--- a/core/auth/models.py
+++ b/core/auth/models.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 from typing import Annotated
 from uuid import UUID, uuid4
 
@@ -7,6 +8,15 @@ from litestar.dto import DTOConfig
 from litestar.plugins.pydantic import PydanticDTO
 from litestar.security.jwt import Token
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, SecretStr
+
+
+class TokenType(str, Enum):
+    """Token type enumeration for different token purposes"""
+
+    AUTH = "auth"  # Regular authenticated user token
+    PASSWORD_RESET = "password_reset"  # Password reset token
+    MAGIC_LINK = "magic_link"  # Magic link login token
+    INVITE = "invite"  # Organisation invite token
 
 
 class Organisation(BaseModel):
@@ -55,8 +65,8 @@ class Identity(BaseModel):
 class AuthToken(Token):
     """AuthToken extends a standard jwt token to include PAS specific details"""
 
+    token_type: TokenType = TokenType.AUTH
     is_api_user: bool = False
-    is_password_reset: bool = False
     organisation_id: str | None = None
     is_super_admin_override: bool = False
 
@@ -72,6 +82,10 @@ class OrganisationInvite(BaseModel):
 class Login(BaseModel):
     email: str
     password: Annotated[SecretStr, Field(min_length=12)]
+
+
+class MagicLinkRequest(BaseModel):
+    email: EmailStr
 
 
 class PasswordChange(BaseModel):

--- a/core/config.py
+++ b/core/config.py
@@ -32,6 +32,8 @@ AUTH_TOKEN_TTL = timedelta(days=30)
 INVITE_TTL = timedelta(days=7)
 # how long a password reset token should last before expiring
 PASSWORD_RESET_TTL = timedelta(minutes=30)
+# how long a magic link token should last before expiring
+MAGIC_LINK_TTL = timedelta(minutes=15)
 
 """email settings"""
 EMAIL_FROM = os.environ.get("EMAIL_FROM", "auto@fullfact.org")

--- a/core/email/messages.py
+++ b/core/email/messages.py
@@ -58,6 +58,25 @@ def password_reset_message(token: str, locale: str) -> tuple[str, str]:
     return subject, body
 
 
+def magic_link_message(token: str, locale: str) -> tuple[str, str]:
+    subject = i18n.t("email.magic_link.subject", locale=locale)
+
+    body = f"""
+    <div style="{container_style}">
+        <h1 style="color: #333;">{subject}</h1>
+        <p style="margin: 2em">{i18n.t("email.magic_link.message", locale=locale)}</p>
+        <p style="margin: 2em">{i18n.t("email.magic_link.not_you", locale=locale)}</p>
+        <p>
+            <a href="{config.APP_BASE_URL}/magic-login?token={token}" style="{button_style}">
+                {i18n.t("email.magic_link.login_link", locale=locale)}
+            </a>
+        </p>
+    <div>
+    """
+
+    return subject, body
+
+
 def alerts_message(
     organisation_name: str, alerts: list[dict], locale: str
 ) -> tuple[str, str]:

--- a/tests/auth/conftest.py
+++ b/tests/auth/conftest.py
@@ -32,6 +32,10 @@ class OrganisationFactory(ModelFactory[Organisation]):
 class UserFactory(ModelFactory[User]):
     __check_model__ = True
 
+    @classmethod
+    def email(cls) -> str:
+        return cls.__faker__.email()
+
 
 @fixture
 async def auth_service(conn_factory) -> AuthService:


### PR DESCRIPTION
This PR adds new API endpoints that allow users to login using their email address only. Instead of entering a password, the user can click on a link sent to their email address, which acts identically to a user having entered an email address and password.

This provides an alternative login route for users who have not yet set a password, without going through the password reset flow.