### PR TITLE
add guards for endpoints that allow modification

### DIFF
--- a/core/alerts/controller.py
+++ b/core/alerts/controller.py
@@ -5,7 +5,13 @@ from litestar import Controller, Request, delete, get, patch, post
 from litestar.di import Provide
 from litestar.status_codes import HTTP_204_NO_CONTENT
 
-from core.alerts.models import Alert, AlertScope, AlertType, CreateAlertRequest, UpdateAlertRequest
+from core.alerts.models import (
+    Alert,
+    AlertScope,
+    AlertType,
+    CreateAlertRequest,
+    UpdateAlertRequest,
+)
 from core.alerts.service import AlertService
 from core.auth.models import AuthToken, Identity
 from core.response import PaginatedJSON
@@ -134,7 +140,7 @@ class AlertController(Controller):
     #         execution,
     #         background=BackgroundTask(send_alert_emails, ...)
     #     )
-    
+
     @get(
         path="/types",
         summary="Get available alert types",

--- a/core/narratives/controller.py
+++ b/core/narratives/controller.py
@@ -5,6 +5,7 @@ from litestar import Controller, delete, get, patch, post
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException
 
+from core.auth.guards import super_admin
 from core.errors import ConflictError
 from core.models import Narrative
 from core.narratives.models import NarrativeInput, NarrativePatchInput
@@ -32,6 +33,7 @@ class NarrativeController(Controller):
         summary="Create a new narrative",
         return_dto=None,
         raises=[ConflictError],
+        guards=[super_admin],
     )
     async def create_narrative(
         self,
@@ -66,7 +68,11 @@ class NarrativeController(Controller):
         text: str | None = None,
     ) -> PaginatedJSON[list[Narrative]]:
         narratives, total = await narrative_service.get_all_narratives(
-            limit=limit, offset=offset, topic_id=topic_id, entity_id=entity_id, text=text
+            limit=limit,
+            offset=offset,
+            topic_id=topic_id,
+            entity_id=entity_id,
+            text=text,
         )
         page = (offset // limit) + 1 if limit > 0 else 1
         return PaginatedJSON(
@@ -120,6 +126,7 @@ class NarrativeController(Controller):
         path="/{narrative_id:uuid}",
         summary="Update a narrative",
         return_dto=None,
+        guards=[super_admin],
     )
     async def update_narrative(
         self,
@@ -135,6 +142,7 @@ class NarrativeController(Controller):
     @patch(
         path="/{narrative_id:uuid}/metadata",
         summary="Update the metadata for a narrative",
+        guards=[super_admin],
     )
     async def patch_narrative_metadata(
         self,
@@ -147,6 +155,7 @@ class NarrativeController(Controller):
     @delete(
         path="/{narrative_id:uuid}",
         summary="Delete a specific narrative",
+        guards=[super_admin],
     )
     async def delete_narrative(
         self,

--- a/core/topics/controller.py
+++ b/core/topics/controller.py
@@ -6,6 +6,7 @@ from litestar.di import Provide
 from litestar.dto import DTOData
 from litestar.exceptions import NotFoundException
 
+from core.auth.guards import super_admin
 from core.errors import ConflictError
 from core.models import Narrative, Topic
 from core.narratives.service import NarrativeService
@@ -51,6 +52,7 @@ class TopicController(Controller):
         dto=TopicDTO,
         return_dto=None,
         raises=[ConflictError],
+        guards=[super_admin],
     )
     async def create_topic(
         self,
@@ -142,6 +144,7 @@ class TopicController(Controller):
         dto=TopicDTO,
         return_dto=None,
         raises=[ConflictError],
+        guards=[super_admin],
     )
     async def update_topic(
         self,
@@ -157,6 +160,7 @@ class TopicController(Controller):
     @patch(
         path="/{topic_id:uuid}/metadata",
         summary="Update the metadata for a topic",
+        guards=[super_admin],
     )
     async def patch_topic_metadata(
         self,
@@ -169,6 +173,7 @@ class TopicController(Controller):
     @delete(
         path="/{topic_id:uuid}",
         summary="Delete a specific topic",
+        guards=[super_admin],
     )
     async def delete_topic(
         self,

--- a/core/videos/claims/controller.py
+++ b/core/videos/claims/controller.py
@@ -7,6 +7,7 @@ from litestar.dto import DTOData
 from litestar.exceptions import NotFoundException
 from litestar.params import Parameter
 
+from core.auth.guards import super_admin
 from core.errors import ConflictError
 from core.models import Claim
 from core.response import JSON, PaginatedJSON
@@ -40,6 +41,7 @@ class ClaimController(Controller):
         dto=VideoClaimsDTO,
         return_dto=None,
         raises=[ConflictError],
+        guards=[super_admin],
     )
     async def add_claims(
         self,
@@ -64,6 +66,7 @@ class ClaimController(Controller):
     @delete(
         path="/",
         summary="Delete all claims for the given video",
+        guards=[super_admin],
     )
     async def delete_claims(
         self, claims_service: ClaimsService, video_id: UUID
@@ -73,6 +76,7 @@ class ClaimController(Controller):
     @patch(
         path="/{claim_id:uuid}/metadata",
         summary="Update the metadata for a claim",
+        guards=[super_admin],
     )
     async def patch_claim_metadata(
         self,
@@ -85,6 +89,7 @@ class ClaimController(Controller):
     @delete(
         path="/{claim_id:uuid}",
         summary="Delete a specific claim",
+        guards=[super_admin],
     )
     async def delete_claim(
         self,
@@ -96,6 +101,7 @@ class ClaimController(Controller):
     @patch(
         path="/{claim_id:uuid}",
         summary="Update claim associations (topics and entities)",
+        guards=[super_admin],
     )
     async def update_claim_associations(
         self,
@@ -138,12 +144,12 @@ class RootClaimController(Controller):
         offset: int = Parameter(0, query="offset", ge=0),
     ) -> PaginatedJSON[list[EnrichedClaim]]:
         claims, total = await claims_service.get_all_claims(
-            limit=limit, 
-            offset=offset, 
-            topic_id=topic_id, 
+            limit=limit,
+            offset=offset,
+            topic_id=topic_id,
             text=text,
             min_score=min_score,
-            max_score=max_score
+            max_score=max_score,
         )
         page = (offset // limit) + 1 if limit > 0 else 1
         return PaginatedJSON(

--- a/core/videos/transcripts/controller.py
+++ b/core/videos/transcripts/controller.py
@@ -6,6 +6,7 @@ from litestar.di import Provide
 from litestar.dto import DTOData
 from litestar.exceptions import NotFoundException
 
+from core.auth.guards import super_admin
 from core.errors import ConflictError
 from core.models import Transcript
 from core.response import JSON
@@ -34,6 +35,7 @@ class TranscriptController(Controller):
         dto=TranscriptDTO,
         return_dto=None,
         raises=[ConflictError],
+        guards=[super_admin],
     )
     async def add_sentences(
         self,
@@ -58,6 +60,7 @@ class TranscriptController(Controller):
     @delete(
         path="/",
         summary="Delete all transcript sentences for the given video",
+        guards=[super_admin],
     )
     async def delete_transcript(
         self, transcript_service: TranscriptService, video_id: UUID
@@ -67,6 +70,7 @@ class TranscriptController(Controller):
     @patch(
         path="/{sentence_id:uuid}/metadata",
         summary="Update the metadata for a transcript sentence",
+        guards=[super_admin],
     )
     async def patch_sentence_metadata(
         self,
@@ -79,6 +83,7 @@ class TranscriptController(Controller):
     @delete(
         path="/{sentence_id:uuid}",
         summary="Delete a specific transcript sentence",
+        guards=[super_admin],
     )
     async def delete_sentence(
         self,


### PR DESCRIPTION
Closes https://linear.app/fullfact/issue/AI-1508/add-endpoint-security-and-guards

Some formatting changes to keep ruff happy, but mostly the addition of super admin guards (which still allow API requests) to endpoints to create / modify / delete:
 - narratives
 - topics
 - videos
 - claims
 - topics
 - transcripts