### PR TITLE
feat: video_language query param added for get claims, videos & narratives endpoint

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -16,6 +16,7 @@ from core.auth import dependencies, middleware
 from core.auth.controller import AuthController
 from core.auth.service import AuthService
 from core.entities.controller import EntityController
+from core.languages.controller import LanguageController
 from core.media_feeds.controller import MediaFeedController
 from core.migrate import migrate
 from core.narratives.controller import NarrativeController
@@ -100,6 +101,7 @@ api_router = Router(
         TopicController,
         MediaFeedController,
         EntityController,
+        LanguageController,
     ],
 )
 

--- a/core/languages/controller.py
+++ b/core/languages/controller.py
@@ -1,0 +1,30 @@
+from typing import Any
+from litestar import Controller, Response, get
+from litestar.datastructures import State
+from litestar.di import Provide
+from core.response import JSON
+from core.videos.service import VideoService
+
+async def video_service(state: State) -> VideoService:
+    return VideoService(state.connection_factory)
+
+class LanguageController(Controller):
+    path = "/languages"
+    tags = ["languages"]
+
+    dependencies = {
+        "video_service": Provide(video_service),
+    }
+
+    @get(
+        path="/",
+        summary="Get a list of languages associated with videos and its count",
+    )
+    async def get_languages(self,
+        video_service: VideoService,
+    ) -> Response[JSON|dict[str, Any]]:
+        try:
+            languages = await video_service.get_languages_associated_with_videos()
+            return Response(JSON(languages))
+        except Exception as e:
+            return Response(status_code=500, content={"error": str(e)})

--- a/core/narratives/service.py
+++ b/core/narratives/service.py
@@ -85,6 +85,7 @@ class NarrativeService:
         offset: int = 0,
         topic_id: UUID | None = None,
         entity_id: UUID | None = None,
+        video_language: str | None = None,
         text: str | None = None
     ) -> tuple[list[Narrative], int]:
         async with self.repo() as repo:
@@ -93,10 +94,11 @@ class NarrativeService:
                 offset=offset,
                 topic_id=topic_id,
                 entity_id=entity_id,
+                video_language=video_language,
                 text=text
             )
             total = await repo.count_all_narratives(
-                topic_id=topic_id, entity_id=entity_id, text=text
+                topic_id=topic_id, entity_id=entity_id, text=text, video_language=video_language
             )
             return narratives, total
 

--- a/core/videos/claims/controller.py
+++ b/core/videos/claims/controller.py
@@ -132,6 +132,7 @@ class RootClaimController(Controller):
         claims_service: ClaimsService,
         topic_id: UUID | None = Parameter(None, query="topic_id"),
         text: str | None = Parameter(None, query="text"),
+        video_language: str | None = Parameter(None, query="video_language"),
         min_score: float | None = Parameter(None, query="min_score"),
         max_score: float | None = Parameter(None, query="max_score"),
         limit: int = Parameter(100, query="limit", gt=0, le=1000),
@@ -142,6 +143,7 @@ class RootClaimController(Controller):
             offset=offset, 
             topic_id=topic_id, 
             text=text,
+            video_language=video_language,
             min_score=min_score,
             max_score=max_score
         )

--- a/core/videos/claims/service.py
+++ b/core/videos/claims/service.py
@@ -105,6 +105,7 @@ class ClaimsService:
         offset: int = 0, 
         topic_id: UUID | None = None,
         text: str | None = None,
+        video_language: str | None = None,
         min_score: float | None = None,
         max_score: float | None = None
     ) -> tuple[list[EnrichedClaim], int]:
@@ -114,6 +115,7 @@ class ClaimsService:
                 offset=offset, 
                 topic_id=topic_id, 
                 text=text,
+                video_language=video_language,
                 min_score=min_score,
                 max_score=max_score
             )

--- a/core/videos/controller.py
+++ b/core/videos/controller.py
@@ -224,6 +224,7 @@ class VideoController(Controller):
         platform: str | None = Parameter(None, query="platform"),
         channel: str | None = Parameter(None, query="channel"),
         text: str | None = Parameter(None, query="text"),
+        video_language: str | None = Parameter(None, query="video_language"),
         limit: int = Parameter(25, query="limit", gt=0, le=100),
         offset: int = Parameter(0, query="offset", ge=0),
     ) -> PaginatedJSON[list[AnalysedVideo]]:
@@ -233,6 +234,7 @@ class VideoController(Controller):
             platform=platform,
             channel=channel,
             text=text,
+            video_language=video_language,
         )
 
         # Fetch claims and narratives for each video

--- a/core/videos/repo.py
+++ b/core/videos/repo.py
@@ -178,6 +178,7 @@ class VideoRepository:
         platform: str | None = None,
         channel: str | None = None,
         text: str | None = None,
+        video_language: str | None = None,
     ) -> tuple[list[Video], int]:
         wheres = [sql.SQL("1=1")]
         params: dict[str, Any] = {"limit": limit, "offset": offset}
@@ -193,6 +194,10 @@ class VideoRepository:
         if text:
             wheres.append(sql.SQL("(LOWER(title) LIKE LOWER(%(text)s) OR LOWER(description) LIKE LOWER(%(text)s))"))
             params["text"] = f"%{text}%"
+
+        if video_language:
+            wheres.append(sql.SQL("metadata->>'language' = %(video_language)s"))
+            params["video_language"] = video_language
 
         where_clause = sql.Composed(wheres).join(" AND ")
 
@@ -233,3 +238,15 @@ class VideoRepository:
             {"video_id": video_id},
         )
         return [Narrative(**row) for row in await self._session.fetchall()]
+
+    async def get_languages_associated_with_videos(self) -> list[dict[str, Any]]:
+        await self._session.execute(
+            """
+            SELECT metadata['language'] as language, count(*)
+            FROM videos
+            WHERE metadata ? 'language'
+            GROUP BY metadata['language']
+            ORDER BY count(*) DESC
+            """,
+        )
+        return await self._session.fetchall()

--- a/core/videos/service.py
+++ b/core/videos/service.py
@@ -1,4 +1,4 @@
-from typing import AsyncContextManager
+from typing import Any, AsyncContextManager
 from uuid import UUID
 
 from litestar.dto import DTOData
@@ -52,12 +52,17 @@ class VideoService:
         platform: str | None = None,
         channel: str | None = None,
         text: str | None = None,
+        video_language: str | None = None,
     ) -> tuple[list[Video], int]:
         async with self.repo() as repo:
             return await repo.get_videos_paginated(
-                limit, offset, platform, channel, text
+                limit, offset, platform, channel, text, video_language
             )
 
     async def get_narratives_for_video(self, video_id: UUID) -> list[Narrative]:
         async with self.repo() as repo:
             return await repo.get_narratives_for_video(video_id)
+
+    async def get_languages_associated_with_videos(self) -> list[dict[str, Any]]:
+        async with self.repo() as repo:
+            return await repo.get_languages_associated_with_videos()


### PR DESCRIPTION
This Pull Request adds/updates the following endpoints:

- `GET /api/languages` **(new)**: Gets a list of the detected languages that are related to the uploaded videos. This list of languages is intended to be used to filter claims, videos & narratives that matches the language associated with the video. The data is retrieved by the following query:

```SQL
SELECT metadata['language'], count(*) FROM videos WHERE metadata ? 'language' GROUP BY metadata['language'] ORDER BY count(*) DESC; 
```

- `GET /api/videos`: Added `video_language` query parameter to filter the videos whose content is in the specified language.

- `GET /api/claims`: Added `video_language` query parameter to filter the claims that have at least one associated video with the provided language.

- `GET /api/narratives`: Added `video_language` query parameter to filter the narratives that have at least one associated claim with videos in the specified language.

