### PR TITLE
fix: send feedback_text to external narratives api

### DIFF
--- a/core/feedback/service.py
+++ b/core/feedback/service.py
@@ -35,6 +35,7 @@ class FeedbackService:
             await self.send_feedback_score_to_external_narratives_api(
                 narrative_id=narrative_id,
                 feedback_score=feedback_score,
+                comment=feedback_text,
             )
             logger.info(f"Successfully sent narrative feedback to external API: narrative_id={narrative_id}, score={feedback_score}")
 
@@ -66,6 +67,7 @@ class FeedbackService:
                 narrative_id=narrative_id,
                 feedback_score=feedback_score,
                 content_id=claim_id,  # Use claim_id as content_id
+                comment=feedback_text,
             )
             logger.info(f"Successfully sent claim-narrative feedback to external API: claim_id={claim_id}, narrative_id={narrative_id}, score={feedback_score}")
 
@@ -82,7 +84,13 @@ class FeedbackService:
         async with self.repo() as repo:
             return await repo.get_claim_narrative_feedback(user_id, claim_id, narrative_id)
 
-    async def send_feedback_score_to_external_narratives_api(self, narrative_id: UUID, feedback_score: float, content_id: UUID | None = None) -> None:
+    async def send_feedback_score_to_external_narratives_api(
+        self,
+        narrative_id: UUID,
+        feedback_score: float,
+        content_id: UUID | None = None,
+        comment: str | None = None,
+    ) -> None:
         """Send feedback score to external analytics service."""
         if not _api.is_configured():
             return
@@ -91,6 +99,7 @@ class FeedbackService:
             narrative_id=narrative_id,
             feedback_score=feedback_score,
             content_id=content_id,
+            comment=comment,
         )
 
         if response.status_code >= 400:

--- a/core/feedback/service.py
+++ b/core/feedback/service.py
@@ -38,7 +38,7 @@ class FeedbackService:
                 comment=feedback_text,
                 user_id=user_id,
             )
-            logger.info(f"Successfully sent narrative feedback to external API: narrative_id={narrative_id}, score={feedback_score}")
+            logger.info(f"Successfully sent narrative feedback to external API: narrative_id={narrative_id}, score={feedback_score}, user_id={user_id}")
 
             # Only save to database if external API call succeeded
             feedback = await repo.submit_narrative_feedback(user_id, narrative_id, feedback_score, feedback_text)

--- a/core/feedback/service.py
+++ b/core/feedback/service.py
@@ -36,6 +36,7 @@ class FeedbackService:
                 narrative_id=narrative_id,
                 feedback_score=feedback_score,
                 comment=feedback_text,
+                user_id=user_id,
             )
             logger.info(f"Successfully sent narrative feedback to external API: narrative_id={narrative_id}, score={feedback_score}")
 
@@ -68,8 +69,9 @@ class FeedbackService:
                 feedback_score=feedback_score,
                 content_id=claim_id,  # Use claim_id as content_id
                 comment=feedback_text,
+                user_id=user_id,
             )
-            logger.info(f"Successfully sent claim-narrative feedback to external API: claim_id={claim_id}, narrative_id={narrative_id}, score={feedback_score}")
+            logger.info(f"Successfully sent claim-narrative feedback to external API: claim_id={claim_id}, narrative_id={narrative_id}, score={feedback_score}, user_id={user_id}")
 
             # Only save to database if external API call succeeded
             feedback = await repo.submit_claim_narrative_feedback(user_id, claim_id, narrative_id, feedback_score, feedback_text)
@@ -90,6 +92,7 @@ class FeedbackService:
         feedback_score: float,
         content_id: UUID | None = None,
         comment: str | None = None,
+        user_id: UUID | None = None,
     ) -> None:
         """Send feedback score to external analytics service."""
         if not _api.is_configured():
@@ -100,6 +103,7 @@ class FeedbackService:
             feedback_score=feedback_score,
             content_id=content_id,
             comment=comment,
+            user_id=user_id,
         )
 
         if response.status_code >= 400:

--- a/core/narratives/api.py
+++ b/core/narratives/api.py
@@ -86,6 +86,7 @@ class NarrativesApiClient:
         narrative_id: UUID,
         feedback_score: float,
         content_id: UUID | None = None,
+        comment: str | None = None,
     ) -> httpx.Response:
         url = f"{NARRATIVES_BASE_URL}/feedback"
         payload: dict[str, str | float] = {
@@ -94,6 +95,8 @@ class NarrativesApiClient:
         }
         if content_id:
             payload["content_id"] = str(content_id)
+        if comment:
+            payload["comment"] = comment
 
         async with httpx.AsyncClient() as client:
             return await client.post(

--- a/core/narratives/api.py
+++ b/core/narratives/api.py
@@ -87,6 +87,7 @@ class NarrativesApiClient:
         feedback_score: float,
         content_id: UUID | None = None,
         comment: str | None = None,
+        user_id: UUID | None = None,
     ) -> httpx.Response:
         url = f"{NARRATIVES_BASE_URL}/feedback"
         payload: dict[str, str | float] = {
@@ -97,6 +98,8 @@ class NarrativesApiClient:
             payload["content_id"] = str(content_id)
         if comment:
             payload["comment"] = comment
+        if user_id:
+            payload["user_id"] = str(user_id)
 
         async with httpx.AsyncClient() as client:
             return await client.post(

--- a/tests/narratives/test_api_client.py
+++ b/tests/narratives/test_api_client.py
@@ -1,0 +1,89 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from core.narratives import api as api_module
+
+
+@pytest.fixture
+def configured_api(monkeypatch: pytest.MonkeyPatch) -> api_module.NarrativesApiClient:
+    monkeypatch.setattr(api_module, "NARRATIVES_BASE_URL", "https://example.test")
+    monkeypatch.setattr(api_module, "NARRATIVES_API_KEY", "test-token")
+    return api_module.NarrativesApiClient()
+
+
+def _mock_async_client() -> tuple[MagicMock, AsyncMock]:
+    """Build a context-manager mock for httpx.AsyncClient with an awaitable .post."""
+    client_instance = MagicMock()
+    post_mock = AsyncMock(return_value=MagicMock(status_code=200))
+    client_instance.post = post_mock
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client_instance)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm, post_mock
+
+
+async def test_send_feedback_includes_comment_and_user_id(
+    configured_api: api_module.NarrativesApiClient,
+) -> None:
+    narrative_id = uuid4()
+    user_id = uuid4()
+    content_id = uuid4()
+    cm, post_mock = _mock_async_client()
+
+    with patch("core.narratives.api.httpx.AsyncClient", return_value=cm):
+        await configured_api.send_feedback(
+            narrative_id=narrative_id,
+            feedback_score=0.8,
+            content_id=content_id,
+            comment="muy útil",
+            user_id=user_id,
+        )
+
+    assert post_mock.await_count == 1
+    _, kwargs = post_mock.call_args
+    assert kwargs["json"] == {
+        "narrative_id": str(narrative_id),
+        "feedback_score": 0.8,
+        "content_id": str(content_id),
+        "comment": "muy útil",
+        "user_id": str(user_id),
+    }
+    assert kwargs["headers"]["X-API-TOKEN"] == "test-token"
+
+
+async def test_send_feedback_omits_optional_fields_when_missing(
+    configured_api: api_module.NarrativesApiClient,
+) -> None:
+    narrative_id = uuid4()
+    cm, post_mock = _mock_async_client()
+
+    with patch("core.narratives.api.httpx.AsyncClient", return_value=cm):
+        await configured_api.send_feedback(
+            narrative_id=narrative_id,
+            feedback_score=0.5,
+        )
+
+    _, kwargs = post_mock.call_args
+    assert kwargs["json"] == {
+        "narrative_id": str(narrative_id),
+        "feedback_score": 0.5,
+    }
+
+
+async def test_send_feedback_omits_empty_comment(
+    configured_api: api_module.NarrativesApiClient,
+) -> None:
+    narrative_id = uuid4()
+    cm, post_mock = _mock_async_client()
+
+    with patch("core.narratives.api.httpx.AsyncClient", return_value=cm):
+        await configured_api.send_feedback(
+            narrative_id=narrative_id,
+            feedback_score=0.0,
+            comment="",
+        )
+
+    _, kwargs = post_mock.call_args
+    assert "comment" not in kwargs["json"]


### PR DESCRIPTION
This PR adds the `comment` & `user_id` paremeters to submit feedback on the external narratives api which allows analyzing feedback beyond the rating scores.

