### PR TITLE
feat: enhance get entities endpoint

### DIFF
--- a/core/entities/controller.py
+++ b/core/entities/controller.py
@@ -4,6 +4,7 @@ from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException
 
+from core.entities.models import EnrichedEntity
 from core.entities.service import EntityService
 from core.models import Entity, Narrative
 from core.narratives.service import NarrativeService
@@ -52,9 +53,18 @@ class EntityController(Controller):
         offset: int = 0,
         text: str | None = None,
         hours: int | None = None,
-    ) -> PaginatedJSON[list[Entity]]:
+        language: str | None = None,
+        narratives_min: int | None = None,
+        narratives_max: int | None = None,
+    ) -> PaginatedJSON[list[EnrichedEntity]]:
         entities, total = await entity_service.get_all_entities(
-            limit=limit, offset=offset, text=text, hours=hours
+            limit=limit,
+            offset=offset,
+            text=text,
+            hours=hours,
+            language=language,
+            narratives_min=narratives_min,
+            narratives_max=narratives_max,
         )
         page = (offset // limit) + 1 if limit > 0 else 1
         return PaginatedJSON(

--- a/core/entities/controller.py
+++ b/core/entities/controller.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from litestar import Controller, get
 from litestar.di import Provide
-from litestar.exceptions import NotFoundException
+from litestar.exceptions import NotFoundException, ValidationException
 
 from core.entities.models import EnrichedEntity
 from core.entities.service import EntityService
@@ -57,6 +57,17 @@ class EntityController(Controller):
         narratives_min: int | None = None,
         narratives_max: int | None = None,
     ) -> PaginatedJSON[list[EnrichedEntity]]:
+        if narratives_min is not None and narratives_min < 0:
+            raise ValidationException("narratives_min must be >= 0")
+        if narratives_max is not None and narratives_max < 0:
+            raise ValidationException("narratives_max must be >= 0")
+        if (
+            narratives_min is not None
+            and narratives_max is not None
+            and narratives_min > narratives_max
+        ):
+            raise ValidationException("narratives_min must be <= narratives_max")
+
         entities, total = await entity_service.get_all_entities(
             limit=limit,
             offset=offset,

--- a/core/entities/models.py
+++ b/core/entities/models.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from typing import Any
+from uuid import UUID
 
 from pydantic import BaseModel
 
@@ -14,3 +16,18 @@ class EntityInput(BaseModel):
 class EntityUpdate(BaseModel):
     """Model for updating entities in claims/narratives"""
     entities: list[EntityInput] = []
+
+
+class EnrichedEntity(BaseModel):
+    """Entity model enriched with statistics"""
+    id: UUID
+    wikidata_id: str
+    name: str
+    metadata: dict[str, Any] = {}
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    total_claims: int = 0
+    total_videos: int = 0
+    linked_narratives: int = 0
+    platforms: list[str] = []
+    languages: list[str] = []

--- a/core/entities/models.py
+++ b/core/entities/models.py
@@ -1,15 +1,15 @@
-from datetime import datetime
 from typing import Any
-from uuid import UUID
 
 from pydantic import BaseModel
+
+from core.models import Entity
 
 
 class EntityInput(BaseModel):
     """Model for incoming entity data from PATCH requests"""
     wikidata_id: str
-    entity_name: str 
-    entity_type: str | None = None 
+    entity_name: str
+    entity_type: str | None = None
     wikidata_info: dict[str, Any] = {}
 
 
@@ -18,14 +18,8 @@ class EntityUpdate(BaseModel):
     entities: list[EntityInput] = []
 
 
-class EnrichedEntity(BaseModel):
-    """Entity model enriched with statistics"""
-    id: UUID
-    wikidata_id: str
-    name: str
-    metadata: dict[str, Any] = {}
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
+class EnrichedEntity(Entity):
+    """Entity model enriched with usage statistics"""
     total_claims: int = 0
     total_videos: int = 0
     linked_narratives: int = 0

--- a/core/entities/repo.py
+++ b/core/entities/repo.py
@@ -5,6 +5,7 @@ import psycopg
 from psycopg.rows import DictRow
 from psycopg.types.json import Jsonb
 
+from core.entities.models import EnrichedEntity
 from core.models import Entity
 
 
@@ -230,23 +231,163 @@ class EntityRepository:
             for row in rows
         ]
 
-    async def count_all_entities(self, text: str | None = None, hours: int | None = None) -> int:
-        """Count total entities with optional text filter"""
-        query = "SELECT COUNT(*) FROM entities"
-        params: dict = {"hours": hours}
-
+    async def count_all_entities(
+        self,
+        text: str | None = None,
+        hours: int | None = None,
+        language: str | None = None,
+        narratives_min: int | None = None,
+        narratives_max: int | None = None,
+    ) -> int:
+        """Count total entities with optional text, hours, language, and narratives range filters"""
+        params: dict = {}
         conditions = []
 
+        needs_having = narratives_min is not None or narratives_max is not None
+        needs_joins = language is not None or needs_having
+
+        if needs_having:
+            query = "SELECT COUNT(*) FROM (\n    SELECT e.id\n    FROM entities e"
+        else:
+            query = "SELECT COUNT(DISTINCT e.id)\nFROM entities e"
+
+        if needs_joins:
+            query += """
+            LEFT JOIN claim_entities ce ON e.id = ce.entity_id
+            LEFT JOIN claim_narratives cn ON ce.claim_id = cn.claim_id
+            LEFT JOIN video_claims c ON cn.claim_id = c.id
+            LEFT JOIN videos v ON c.video_id = v.id
+            LEFT JOIN narrative_entities ne ON e.id = ne.entity_id
+            LEFT JOIN narratives n ON ne.narrative_id = n.id"""
+
         if hours is not None:
-            conditions.append("updated_at >= NOW() - %(hours)s * INTERVAL '1 hour'")
+            conditions.append("e.updated_at >= NOW() - %(hours)s * INTERVAL '1 hour'")
+            params["hours"] = hours
 
         if text:
-            conditions.append("name ILIKE %(text)s")
+            conditions.append("e.name ILIKE %(text)s")
             params["text"] = f"%{text}%"
 
+        if language:
+            conditions.append("v.metadata->>'language' = %(language)s")
+            params["language"] = language
+
         if conditions:
-            query += " WHERE " + " AND ".join(conditions)
+            query += "\n        WHERE " + " AND ".join(conditions)
+
+        if needs_having:
+            query += "\n        GROUP BY e.id"
+
+            if narratives_min is not None and narratives_max is not None:
+                query += "\n        HAVING COUNT(DISTINCT n.id) BETWEEN %(narratives_min)s AND %(narratives_max)s"
+                params["narratives_min"] = narratives_min
+                params["narratives_max"] = narratives_max
+            elif narratives_min is not None:
+                query += "\n        HAVING COUNT(DISTINCT n.id) >= %(narratives_min)s"
+                params["narratives_min"] = narratives_min
+            elif narratives_max is not None:
+                query += "\n        HAVING COUNT(DISTINCT n.id) <= %(narratives_max)s"
+                params["narratives_max"] = narratives_max
+
+            query += "\n) AS filtered_entities"
 
         await self._session.execute(query, params)
         row = await self._session.fetchone()
         return row["count"] if row else 0
+
+    async def get_all_enriched_entities(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        text: str | None = None,
+        hours: int | None = None,
+        language: str | None = None,
+        narratives_min: int | None = None,
+        narratives_max: int | None = None,
+    ) -> list[EnrichedEntity]:
+        """Get all entities with statistics (claims, videos, platforms, languages, narratives)"""
+        query = """
+            SELECT 
+                e.id, 
+                e.wikidata_id, 
+                e.name, 
+                e.metadata, 
+                e.created_at, 
+                e.updated_at,
+                COUNT(DISTINCT c.id) as total_claims, 
+                COUNT(DISTINCT v.id) as total_videos,
+                COUNT(DISTINCT n.id) as linked_narratives,
+                COALESCE(
+                    array_agg(DISTINCT v.platform) FILTER (WHERE v.platform IS NOT NULL),
+                    ARRAY[]::text[]
+                ) as platforms,
+                COALESCE(
+                    array_agg(DISTINCT v.metadata->>'language') FILTER (WHERE v.metadata->>'language' IS NOT NULL),
+                    ARRAY[]::text[]
+                ) as languages
+            FROM entities e
+            LEFT JOIN claim_entities ce ON e.id = ce.entity_id
+            LEFT JOIN claim_narratives cn ON ce.claim_id = cn.claim_id
+            LEFT JOIN video_claims c ON cn.claim_id = c.id
+            LEFT JOIN videos v ON c.video_id = v.id
+            LEFT JOIN narrative_entities ne ON e.id = ne.entity_id
+            LEFT JOIN narratives n ON ne.narrative_id = n.id
+        """
+        params: dict = {"limit": limit, "offset": offset}
+        conditions = []
+
+        if hours is not None:
+            conditions.append("e.updated_at >= NOW() - %(hours)s * INTERVAL '1 hour'")
+            params["hours"] = hours
+
+        if text:
+            conditions.append("e.name ILIKE %(text)s")
+            params["text"] = f"%{text}%"
+
+        if language:
+            conditions.append("v.metadata->>'language' = %(language)s")
+            params["language"] = language
+
+        if conditions:
+            query += " WHERE " + " AND ".join(conditions)
+
+        query += """
+            GROUP BY e.id, e.wikidata_id, e.name, e.metadata, e.created_at, e.updated_at
+        """
+        
+        # Add HAVING clause for narratives filter
+        if narratives_min is not None and narratives_max is not None:
+            query += " HAVING COUNT(DISTINCT n.id) BETWEEN %(narratives_min)s AND %(narratives_max)s"
+            params["narratives_min"] = narratives_min
+            params["narratives_max"] = narratives_max
+        elif narratives_min is not None:
+            query += " HAVING COUNT(DISTINCT n.id) >= %(narratives_min)s"
+            params["narratives_min"] = narratives_min
+        elif narratives_max is not None:
+            query += " HAVING COUNT(DISTINCT n.id) <= %(narratives_max)s"
+            params["narratives_max"] = narratives_max
+        
+        query += """
+            ORDER BY e.created_at DESC 
+            LIMIT %(limit)s OFFSET %(offset)s
+        """
+
+        await self._session.execute(query, params)
+        rows = await self._session.fetchall()
+
+        return [
+            EnrichedEntity(
+                id=row["id"],
+                wikidata_id=row["wikidata_id"],
+                name=row["name"],
+                metadata=row["metadata"],
+                created_at=row["created_at"],
+                updated_at=row["updated_at"],
+                total_claims=row["total_claims"],
+                total_videos=row["total_videos"],
+                linked_narratives=row["linked_narratives"],
+                platforms=row["platforms"] or [],
+                languages=row["languages"] or [],
+            )
+            for row in rows
+        ]

--- a/core/entities/repo.py
+++ b/core/entities/repo.py
@@ -188,48 +188,103 @@ class EntityRepository:
             updated_at=row["updated_at"],
         )
 
-    async def get_all_entities(
-        self,
-        limit: int = 100,
-        offset: int = 0,
-        text: str | None = None,
-        hours: int | None = None
-    ) -> list[Entity]:
-        """Get all entities with pagination and optional text search"""
-        query = """
-            SELECT id, wikidata_id, name, metadata, created_at, updated_at
-            FROM entities
-        """
-        params: dict = {"limit": limit, "offset": offset, "hours": hours}
+    _ENRICHED_CTES = """
+        WITH entity_video_stats AS (
+            SELECT
+                ce.entity_id,
+                COUNT(DISTINCT c.id) AS total_claims,
+                COUNT(DISTINCT v.id) AS total_videos,
+                COALESCE(
+                    array_agg(DISTINCT v.platform) FILTER (WHERE v.platform IS NOT NULL),
+                    ARRAY[]::text[]
+                ) AS platforms,
+                COALESCE(
+                    array_agg(DISTINCT v.metadata->>'language')
+                        FILTER (WHERE v.metadata->>'language' IS NOT NULL),
+                    ARRAY[]::text[]
+                ) AS languages
+            FROM claim_entities ce
+            LEFT JOIN video_claims c ON ce.claim_id = c.id
+            LEFT JOIN videos v ON c.video_id = v.id
+            GROUP BY ce.entity_id
+        ),
+        entity_narrative_stats AS (
+            SELECT entity_id, COUNT(*) AS linked_narratives
+            FROM narrative_entities
+            GROUP BY entity_id
+        )
+    """
 
-        conditions = []
+    _LATERAL_STATS_JOIN = """
+        LEFT JOIN LATERAL (
+            SELECT
+                COUNT(DISTINCT c.id) AS total_claims,
+                COUNT(DISTINCT v.id) AS total_videos,
+                COALESCE(
+                    array_agg(DISTINCT v.platform) FILTER (WHERE v.platform IS NOT NULL),
+                    ARRAY[]::text[]
+                ) AS platforms,
+                COALESCE(
+                    array_agg(DISTINCT v.metadata->>'language')
+                        FILTER (WHERE v.metadata->>'language' IS NOT NULL),
+                    ARRAY[]::text[]
+                ) AS languages
+            FROM claim_entities ce
+            LEFT JOIN video_claims c ON ce.claim_id = c.id
+            LEFT JOIN videos v ON c.video_id = v.id
+            WHERE ce.entity_id = e.id
+        ) evs ON true
+        LEFT JOIN LATERAL (
+            SELECT COUNT(*) AS linked_narratives
+            FROM narrative_entities
+            WHERE entity_id = e.id
+        ) ens ON true
+    """
+
+    @staticmethod
+    def _entity_only_filters(text: str | None, hours: int | None) -> tuple[str, dict]:
+        params: dict = {}
+        where: list[str] = []
+        if hours is not None:
+            where.append("e.updated_at >= NOW() - %(hours)s * INTERVAL '1 hour'")
+            params["hours"] = hours
+        if text:
+            where.append("e.name ILIKE %(text)s")
+            params["text"] = f"%{text}%"
+        clause = " WHERE " + " AND ".join(where) if where else ""
+        return clause, params
+
+    @staticmethod
+    def _build_enriched_filters(
+        text: str | None,
+        hours: int | None,
+        language: str | None,
+        narratives_min: int | None,
+        narratives_max: int | None,
+    ) -> tuple[str, dict]:
+        params: dict = {}
+        where: list[str] = []
 
         if hours is not None:
-            conditions.append("updated_at >= NOW() - %(hours)s * INTERVAL '1 hour'")
-
+            where.append("e.updated_at >= NOW() - %(hours)s * INTERVAL '1 hour'")
+            params["hours"] = hours
         if text:
-            conditions.append("name ILIKE %(text)s")
+            where.append("e.name ILIKE %(text)s")
             params["text"] = f"%{text}%"
+        if language is not None:
+            where.append("%(language)s = ANY(COALESCE(evs.languages, ARRAY[]::text[]))")
+            params["language"] = language
+        if narratives_min is not None:
+            where.append("COALESCE(ens.linked_narratives, 0) >= %(narratives_min)s")
+            params["narratives_min"] = narratives_min
+        if narratives_max is not None:
+            where.append("COALESCE(ens.linked_narratives, 0) <= %(narratives_max)s")
+            params["narratives_max"] = narratives_max
 
-        if conditions:
-            query += " WHERE " + " AND ".join(conditions)
-
-        query += " ORDER BY created_at DESC LIMIT %(limit)s OFFSET %(offset)s"
-
-        await self._session.execute(query, params)
-        rows = await self._session.fetchall()
-
-        return [
-            Entity(
-                id=row["id"],
-                wikidata_id=row["wikidata_id"],
-                name=row["name"],
-                metadata=row["metadata"],
-                created_at=row["created_at"],
-                updated_at=row["updated_at"],
-            )
-            for row in rows
-        ]
+        clause = ""
+        if where:
+            clause = " WHERE " + " AND ".join(where)
+        return clause, params
 
     async def count_all_entities(
         self,
@@ -239,57 +294,28 @@ class EntityRepository:
         narratives_min: int | None = None,
         narratives_max: int | None = None,
     ) -> int:
-        """Count total entities with optional text, hours, language, and narratives range filters"""
-        params: dict = {}
-        conditions = []
+        """Count total entities matching the same filters as get_all_enriched_entities."""
+        # Fast path: no aggregate filter, count straight from entities.
+        if language is None and narratives_min is None and narratives_max is None:
+            where_clause, params = self._entity_only_filters(text, hours)
+            query = "SELECT COUNT(*) AS count FROM entities e" + where_clause
+            await self._session.execute(query, params)
+            row = await self._session.fetchone()
+            return row["count"] if row else 0
 
-        needs_having = narratives_min is not None or narratives_max is not None
-        needs_joins = language is not None or needs_having
-
-        if needs_having:
-            query = "SELECT COUNT(*) FROM (\n    SELECT e.id\n    FROM entities e"
-        else:
-            query = "SELECT COUNT(DISTINCT e.id)\nFROM entities e"
-
-        if needs_joins:
-            query += """
-            LEFT JOIN claim_entities ce ON e.id = ce.entity_id
-            LEFT JOIN claim_narratives cn ON ce.claim_id = cn.claim_id
-            LEFT JOIN video_claims c ON cn.claim_id = c.id
-            LEFT JOIN videos v ON c.video_id = v.id
-            LEFT JOIN narrative_entities ne ON e.id = ne.entity_id
-            LEFT JOIN narratives n ON ne.narrative_id = n.id"""
-
-        if hours is not None:
-            conditions.append("e.updated_at >= NOW() - %(hours)s * INTERVAL '1 hour'")
-            params["hours"] = hours
-
-        if text:
-            conditions.append("e.name ILIKE %(text)s")
-            params["text"] = f"%{text}%"
-
-        if language:
-            conditions.append("v.metadata->>'language' = %(language)s")
-            params["language"] = language
-
-        if conditions:
-            query += "\n        WHERE " + " AND ".join(conditions)
-
-        if needs_having:
-            query += "\n        GROUP BY e.id"
-
-            if narratives_min is not None and narratives_max is not None:
-                query += "\n        HAVING COUNT(DISTINCT n.id) BETWEEN %(narratives_min)s AND %(narratives_max)s"
-                params["narratives_min"] = narratives_min
-                params["narratives_max"] = narratives_max
-            elif narratives_min is not None:
-                query += "\n        HAVING COUNT(DISTINCT n.id) >= %(narratives_min)s"
-                params["narratives_min"] = narratives_min
-            elif narratives_max is not None:
-                query += "\n        HAVING COUNT(DISTINCT n.id) <= %(narratives_max)s"
-                params["narratives_max"] = narratives_max
-
-            query += "\n) AS filtered_entities"
+        where_clause, params = self._build_enriched_filters(
+            text, hours, language, narratives_min, narratives_max,
+        )
+        query = (
+            self._ENRICHED_CTES
+            + """
+            SELECT COUNT(*) AS count
+            FROM entities e
+            LEFT JOIN entity_video_stats evs ON e.id = evs.entity_id
+            LEFT JOIN entity_narrative_stats ens ON e.id = ens.entity_id
+            """
+            + where_clause
+        )
 
         await self._session.execute(query, params)
         row = await self._session.fetchone()
@@ -305,72 +331,73 @@ class EntityRepository:
         narratives_min: int | None = None,
         narratives_max: int | None = None,
     ) -> list[EnrichedEntity]:
-        """Get all entities with statistics (claims, videos, platforms, languages, narratives)"""
-        query = """
-            SELECT 
-                e.id, 
-                e.wikidata_id, 
-                e.name, 
-                e.metadata, 
-                e.created_at, 
-                e.updated_at,
-                COUNT(DISTINCT c.id) as total_claims, 
-                COUNT(DISTINCT v.id) as total_videos,
-                COUNT(DISTINCT n.id) as linked_narratives,
-                COALESCE(
-                    array_agg(DISTINCT v.platform) FILTER (WHERE v.platform IS NOT NULL),
-                    ARRAY[]::text[]
-                ) as platforms,
-                COALESCE(
-                    array_agg(DISTINCT v.metadata->>'language') FILTER (WHERE v.metadata->>'language' IS NOT NULL),
-                    ARRAY[]::text[]
-                ) as languages
-            FROM entities e
-            LEFT JOIN claim_entities ce ON e.id = ce.entity_id
-            LEFT JOIN claim_narratives cn ON ce.claim_id = cn.claim_id
-            LEFT JOIN video_claims c ON cn.claim_id = c.id
-            LEFT JOIN videos v ON c.video_id = v.id
-            LEFT JOIN narrative_entities ne ON e.id = ne.entity_id
-            LEFT JOIN narratives n ON ne.narrative_id = n.id
-        """
-        params: dict = {"limit": limit, "offset": offset}
-        conditions = []
-
-        if hours is not None:
-            conditions.append("e.updated_at >= NOW() - %(hours)s * INTERVAL '1 hour'")
-            params["hours"] = hours
-
-        if text:
-            conditions.append("e.name ILIKE %(text)s")
-            params["text"] = f"%{text}%"
-
-        if language:
-            conditions.append("v.metadata->>'language' = %(language)s")
-            params["language"] = language
-
-        if conditions:
-            query += " WHERE " + " AND ".join(conditions)
-
-        query += """
-            GROUP BY e.id, e.wikidata_id, e.name, e.metadata, e.created_at, e.updated_at
-        """
-        
-        # Add HAVING clause for narratives filter
-        if narratives_min is not None and narratives_max is not None:
-            query += " HAVING COUNT(DISTINCT n.id) BETWEEN %(narratives_min)s AND %(narratives_max)s"
-            params["narratives_min"] = narratives_min
-            params["narratives_max"] = narratives_max
-        elif narratives_min is not None:
-            query += " HAVING COUNT(DISTINCT n.id) >= %(narratives_min)s"
-            params["narratives_min"] = narratives_min
-        elif narratives_max is not None:
-            query += " HAVING COUNT(DISTINCT n.id) <= %(narratives_max)s"
-            params["narratives_max"] = narratives_max
-        
-        query += """
-            ORDER BY e.created_at DESC 
-            LIMIT %(limit)s OFFSET %(offset)s
-        """
+        """Get all entities with statistics (claims, videos, platforms, languages, narratives)."""
+        # Fast path: no filter depends on aggregated stats, so page entities first
+        # and compute stats per row via LATERAL — keeps work O(limit) instead of O(N).
+        if language is None and narratives_min is None and narratives_max is None:
+            where_clause, params = self._entity_only_filters(text, hours)
+            params["limit"] = limit
+            params["offset"] = offset
+            query = (
+                """
+                SELECT
+                    e.id,
+                    e.wikidata_id,
+                    e.name,
+                    e.metadata,
+                    e.created_at,
+                    e.updated_at,
+                    COALESCE(evs.total_claims, 0) AS total_claims,
+                    COALESCE(evs.total_videos, 0) AS total_videos,
+                    COALESCE(ens.linked_narratives, 0) AS linked_narratives,
+                    COALESCE(evs.platforms, ARRAY[]::text[]) AS platforms,
+                    COALESCE(evs.languages, ARRAY[]::text[]) AS languages
+                FROM (
+                    SELECT id, wikidata_id, name, metadata, created_at, updated_at
+                    FROM entities e
+                """
+                + where_clause
+                + """
+                    ORDER BY created_at DESC
+                    LIMIT %(limit)s OFFSET %(offset)s
+                ) e
+                """
+                + self._LATERAL_STATS_JOIN
+                + """
+                ORDER BY e.created_at DESC
+                """
+            )
+        else:
+            where_clause, params = self._build_enriched_filters(
+                text, hours, language, narratives_min, narratives_max,
+            )
+            params["limit"] = limit
+            params["offset"] = offset
+            query = (
+                self._ENRICHED_CTES
+                + """
+                SELECT
+                    e.id,
+                    e.wikidata_id,
+                    e.name,
+                    e.metadata,
+                    e.created_at,
+                    e.updated_at,
+                    COALESCE(evs.total_claims, 0) AS total_claims,
+                    COALESCE(evs.total_videos, 0) AS total_videos,
+                    COALESCE(ens.linked_narratives, 0) AS linked_narratives,
+                    COALESCE(evs.platforms, ARRAY[]::text[]) AS platforms,
+                    COALESCE(evs.languages, ARRAY[]::text[]) AS languages
+                FROM entities e
+                LEFT JOIN entity_video_stats evs ON e.id = evs.entity_id
+                LEFT JOIN entity_narrative_stats ens ON e.id = ens.entity_id
+                """
+                + where_clause
+                + """
+                ORDER BY e.created_at DESC
+                LIMIT %(limit)s OFFSET %(offset)s
+                """
+            )
 
         await self._session.execute(query, params)
         rows = await self._session.fetchall()

--- a/core/entities/service.py
+++ b/core/entities/service.py
@@ -1,7 +1,7 @@
 from typing import AsyncContextManager
 from uuid import UUID
 
-from core.entities.models import EntityInput
+from core.entities.models import EnrichedEntity, EntityInput
 from core.entities.repo import EntityRepository
 from core.models import Entity
 from core.uow import ConnectionFactory, uow
@@ -105,15 +105,27 @@ class EntityService:
         limit: int = 100,
         offset: int = 0,
         text: str | None = None,
-        hours: int | None = None
-    ) -> tuple[list[Entity], int]:
-        """Get all entities with pagination and optional text search"""
+        hours: int | None = None,
+        language: str | None = None,
+        narratives_min: int | None = None,
+        narratives_max: int | None = None,
+    ) -> tuple[list[EnrichedEntity], int]:
+        """Get all enriched entities with pagination and optional filters"""
         async with self.repo() as repo:
-            entities = await repo.get_all_entities(
+            entities = await repo.get_all_enriched_entities(
                 limit=limit,
                 offset=offset,
                 text=text,
-                hours=hours
+                hours=hours,
+                language=language,
+                narratives_min=narratives_min,
+                narratives_max=narratives_max,
             )
-            total = await repo.count_all_entities(text=text, hours=hours)
+            total = await repo.count_all_entities(
+                text=text,
+                hours=hours,
+                language=language,
+                narratives_min=narratives_min,
+                narratives_max=narratives_max,
+            )
             return entities, total

--- a/tests/entities/conftest.py
+++ b/tests/entities/conftest.py
@@ -17,6 +17,7 @@ def tables_to_truncate() -> list[str]:
         "narratives",
         "video_claims",
         "claim_narratives",
+        "videos",
     ]
 
 

--- a/tests/entities/test_entities_controller.py
+++ b/tests/entities/test_entities_controller.py
@@ -4,7 +4,9 @@ from litestar import Litestar
 from litestar.testing import AsyncTestClient
 
 from core.entities.models import EntityInput
+from core.models import Claim, Video
 from core.narratives.models import NarrativeInput, NarrativePatchInput
+from core.videos.claims.models import ClaimUpdate
 from tests.entities.conftest import create_entity
 
 
@@ -345,6 +347,124 @@ async def test_get_narratives_by_entity_with_pagination(
     data = response.json()
     assert len(data["data"]) == 1
     assert data["page"] == 2
+
+
+async def _add_video_claim_with_entities(
+    api_key_client: AsyncTestClient[Litestar],
+    *,
+    platform: str,
+    language: str,
+    source_url: str,
+    entities: list[EntityInput],
+) -> None:
+    """Create a video, attach a claim to it, and associate entities to that claim."""
+    video = Video(
+        title=f"video {source_url}",
+        description="d",
+        platform=platform,
+        source_url=source_url,
+        uploaded_at=None,
+        metadata={"language": language},
+    )
+    response = await api_key_client.post(
+        "/api/videos/", json=video.model_dump(mode="json")
+    )
+    assert response.status_code == 201
+
+    claim = Claim(video_id=video.id, claim=f"c {source_url}", start_time_s=0.0)
+    response = await api_key_client.post(
+        f"/api/videos/{video.id}/claims",
+        json={"video_id": str(video.id), "claims": [claim.model_dump(mode="json")]},
+    )
+    assert response.status_code == 201
+    claim_id = response.json()["data"]["claims"][0]["id"]
+
+    response = await api_key_client.patch(
+        f"/api/videos/{video.id}/claims/{claim_id}",
+        json=ClaimUpdate(entities=entities).model_dump(mode="json", exclude_none=True),
+    )
+    assert response.status_code == 200
+
+
+async def test_get_entities_returns_stats_for_claim_only_entity(
+    api_key_client: AsyncTestClient[Litestar]
+) -> None:
+    """Entities linked only via claims (not narratives) must still report total_claims/videos.
+
+    Regression: an earlier query routed video_claims through claim_narratives, which
+    silently zeroed claim/video counts whenever a claim had no narrative.
+    """
+    entity_input = EntityInput(
+        wikidata_id="Q-claimonly",
+        entity_name="Claim Only",
+        entity_type="concept",
+    )
+    await _add_video_claim_with_entities(
+        api_key_client,
+        platform="youtube",
+        language="en",
+        source_url="https://example.com/claim-only",
+        entities=[entity_input],
+    )
+
+    response = await api_key_client.get("/api/entities/?text=Claim Only")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    enriched = data["data"][0]
+    assert enriched["total_claims"] == 1
+    assert enriched["total_videos"] == 1
+    assert enriched["linked_narratives"] == 0
+    assert enriched["platforms"] == ["youtube"]
+    assert enriched["languages"] == ["en"]
+
+
+async def test_get_entities_language_filter_preserves_languages_array(
+    api_key_client: AsyncTestClient[Litestar]
+) -> None:
+    """Filtering by language must not collapse the returned languages array to the filter value."""
+    entity_input = EntityInput(
+        wikidata_id="Q-multi",
+        entity_name="Multi Lang Entity",
+        entity_type="concept",
+    )
+
+    for idx, (lang, platform) in enumerate([("en", "platform0"), ("es", "platform1")]):
+        await _add_video_claim_with_entities(
+            api_key_client,
+            platform=platform,
+            language=lang,
+            source_url=f"https://example.com/multi-{idx}",
+            entities=[entity_input],
+        )
+
+    response = await api_key_client.get("/api/entities/?language=en")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    enriched = data["data"][0]
+    assert set(enriched["languages"]) == {"en", "es"}
+    assert set(enriched["platforms"]) == {"platform0", "platform1"}
+
+    response = await api_key_client.get("/api/entities/?language=de")
+    assert response.status_code == 200
+    assert response.json()["total"] == 0
+
+
+async def test_get_entities_narratives_filter_validation(
+    api_key_client: AsyncTestClient[Litestar]
+) -> None:
+    """narratives_min/max must reject negative or inverted ranges."""
+    response = await api_key_client.get("/api/entities/?narratives_min=-1")
+    assert response.status_code == 400
+
+    response = await api_key_client.get("/api/entities/?narratives_max=-2")
+    assert response.status_code == 400
+
+    response = await api_key_client.get(
+        "/api/entities/?narratives_min=5&narratives_max=2"
+    )
+    assert response.status_code == 400
 
 
 async def test_get_narratives_by_entity_empty(


### PR DESCRIPTION
This Pull Request updates the `GET /api/entities` endpoint by adding new filters to search entities by language & amount of related narratives. 

Also, the endpoint was updated to return extra information related to the entity as it is required by the frontend to display helpful information to identify the entities. The new data that the endpoint returns contains: 
- the total of videos and claims where each entity appears on
- the platforms where the videos from the entity are being shared & 
- the total of languages from the videos where the entity has been related to.

