### PR TITLE
fix: use topic_id for keyword feeds

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -29,7 +29,7 @@ from core.videos.claims.controller import ClaimController, RootClaimController
 from core.videos.controller import VideoController
 from core.videos.transcripts.controller import TranscriptController
 
-MIGRATION_TARGET_VERSION = 17
+MIGRATION_TARGET_VERSION = 18
 
 postgres_url = f"postgresql://{config.DB_USER}:{config.DB_PASSWORD}@{config.DB_HOST}:{config.DB_PORT}/{config.DB_NAME}"
 

--- a/core/media_feeds/controller.py
+++ b/core/media_feeds/controller.py
@@ -338,7 +338,7 @@ class MediaFeedController(Controller):
         return JSON(
             await media_feeds_service.create_keyword_feed(
                 organisation_id=keyword_data.organisation_id,
-                topic=keyword_data.topic,
+                topic_id=keyword_data.topic_id,
                 keywords=keyword_data.keywords,
             )
         )

--- a/core/media_feeds/models.py
+++ b/core/media_feeds/models.py
@@ -21,7 +21,8 @@ class MediaFeed(BaseModel, abc.ABC):
 
 
 class KeywordFeed(MediaFeed):
-    topic: str
+    topic_id: UUID
+    topic_name: str = ""
     keywords: list[str]
 
 
@@ -66,6 +67,7 @@ class KeywordFeedDTO(PydanticDTO[KeywordFeed]):
             "is_archived",
             "created_at",
             "updated_at",
+            "topic_name",
         },
     )
 

--- a/core/media_feeds/repo.py
+++ b/core/media_feeds/repo.py
@@ -68,11 +68,13 @@ class MediaFeedRepository:
     ) -> list[KeywordFeed]:
         await self._session.execute(
             """
-            SELECT * FROM keyword_feeds
+            SELECT kf.*, t.topic AS topic_name
+            FROM keyword_feeds kf
+            JOIN topics t ON t.id = kf.topic_id
             WHERE
-                (%(organisation_id)s::uuid IS NULL OR organisation_id = %(organisation_id)s::uuid)
-                AND NOT is_archived
-            ORDER BY organisation_id, created_at DESC
+                (%(organisation_id)s::uuid IS NULL OR kf.organisation_id = %(organisation_id)s::uuid)
+                AND NOT kf.is_archived
+            ORDER BY kf.organisation_id, kf.created_at DESC
         """,
             {"organisation_id": str(organisation_id) if organisation_id else None},
         )
@@ -83,10 +85,12 @@ class MediaFeedRepository:
     ) -> KeywordFeed | None:
         await self._session.execute(
             """
-            SELECT * FROM keyword_feeds
-            WHERE id = %(feed_id)s
-                AND NOT is_archived
-                AND (%(organisation_id)s::uuid IS NULL OR organisation_id = %(organisation_id)s::uuid)
+            SELECT kf.*, t.topic AS topic_name
+            FROM keyword_feeds kf
+            JOIN topics t ON t.id = kf.topic_id
+            WHERE kf.id = %(feed_id)s
+                AND NOT kf.is_archived
+                AND (%(organisation_id)s::uuid IS NULL OR kf.organisation_id = %(organisation_id)s::uuid)
             """,
             {
                 "feed_id": str(feed_id),
@@ -155,27 +159,34 @@ class MediaFeedRepository:
         return created_feeds
 
     async def create_keyword_feed(
-        self, organisation_id: UUID, topic: str, keywords: list[str]
+        self, organisation_id: UUID, topic_id: UUID, keywords: list[str]
     ) -> KeywordFeed:
         try:
             await self._session.execute(
                 """
-                INSERT INTO keyword_feeds (organisation_id, topic, keywords)
-                VALUES (%(organisation_id)s, %(topic)s, %(keywords)s)
-                RETURNING *
+                WITH inserted AS (
+                    INSERT INTO keyword_feeds (organisation_id, topic_id, keywords)
+                    VALUES (%(organisation_id)s, %(topic_id)s, %(keywords)s)
+                    RETURNING *
+                )
+                SELECT inserted.*, t.topic AS topic_name
+                FROM inserted
+                JOIN topics t ON t.id = inserted.topic_id
                 """,
                 {
                     "organisation_id": str(organisation_id),
-                    "topic": topic,
+                    "topic_id": str(topic_id),
                     "keywords": keywords,
                 },
             )
         except psycopg.errors.UniqueViolation:
             raise ConflictError("keyword already exists")
+        except psycopg.errors.ForeignKeyViolation:
+            raise ValueError(f"topic {topic_id} does not exist")
 
         row = await self._session.fetchone()
         if not row:
-            raise ValueError("failed to create topic")
+            raise ValueError("failed to create keyword feed")
 
         return KeywordFeed(**row)
 
@@ -212,26 +223,34 @@ class MediaFeedRepository:
     async def update_keyword_feed(
         self,
         feed_id: UUID,
-        topic: str,
+        topic_id: UUID,
         keywords: list[str],
         organisation_id: UUID | None = None,
     ) -> KeywordFeed:
-        await self._session.execute(
-            """
-            UPDATE keyword_feeds
-            SET topic = %(topic)s, keywords = %(keywords)s, updated_at = NOW()
-            WHERE id = %(feed_id)s
-            AND NOT is_archived
-            AND (%(organisation_id)s::uuid IS NULL OR organisation_id = %(organisation_id)s::uuid)
-            RETURNING *
-            """,
-            {
-                "feed_id": str(feed_id),
-                "topic": topic,
-                "keywords": keywords,
-                "organisation_id": str(organisation_id) if organisation_id else None,
-            },
-        )
+        try:
+            await self._session.execute(
+                """
+                WITH updated AS (
+                    UPDATE keyword_feeds
+                    SET topic_id = %(topic_id)s, keywords = %(keywords)s, updated_at = NOW()
+                    WHERE id = %(feed_id)s
+                    AND NOT is_archived
+                    AND (%(organisation_id)s::uuid IS NULL OR organisation_id = %(organisation_id)s::uuid)
+                    RETURNING *
+                )
+                SELECT updated.*, t.topic AS topic_name
+                FROM updated
+                JOIN topics t ON t.id = updated.topic_id
+                """,
+                {
+                    "feed_id": str(feed_id),
+                    "topic_id": str(topic_id),
+                    "keywords": keywords,
+                    "organisation_id": str(organisation_id) if organisation_id else None,
+                },
+            )
+        except psycopg.errors.ForeignKeyViolation:
+            raise ValueError(f"topic {topic_id} does not exist")
 
         row = await self._session.fetchone()
         if not row:

--- a/core/media_feeds/service.py
+++ b/core/media_feeds/service.py
@@ -66,10 +66,10 @@ class MediaFeedsService:
             return await repo.bulk_create_channel_feeds(organisation_id, channels)
 
     async def create_keyword_feed(
-        self, organisation_id: UUID, topic: str, keywords: list[str]
+        self, organisation_id: UUID, topic_id: UUID, keywords: list[str]
     ) -> KeywordFeed:
         async with self.repo() as repo:
-            return await repo.create_keyword_feed(organisation_id, topic, keywords)
+            return await repo.create_keyword_feed(organisation_id, topic_id, keywords)
 
     async def update_channel_feed(
         self, organisation_id: UUID, feed_id: UUID, data: DTOData[ChannelFeed]
@@ -94,7 +94,7 @@ class MediaFeedsService:
             data.update_instance(feed)
 
             return await repo.update_keyword_feed(
-                feed_id, feed.topic, feed.keywords, organisation_id
+                feed_id, feed.topic_id, feed.keywords, organisation_id
             )
 
     async def archive_channel_feed(self, organisation_id: UUID, feed_id: UUID) -> None:

--- a/core/migrations/18.keyword-feeds-topic-to-uuid.up.sql
+++ b/core/migrations/18.keyword-feeds-topic-to-uuid.up.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+-- Convert old topic name values to their corresponding UUIDs
+UPDATE keyword_feeds
+SET topic = CASE topic
+    WHEN 'public health' THEN 'bb52f622-b9ee-4d5b-9b70-5fd05046528b'
+    WHEN 'eu'            THEN 'ff1bedb9-43e4-49e6-9c3f-27babfb7bfa1'
+    WHEN 'climate'       THEN 'db3d996b-e691-4ce5-8c46-e35a82a9b28c'
+    WHEN 'migration'     THEN '3cd4a9cd-5906-4b0b-9167-57ff22c2345a'
+    WHEN 'conflict'      THEN '0d7aaf8d-5b7e-4c0c-b03a-28457e27ac7d'
+END
+WHERE topic IN ('public health', 'eu', 'climate', 'migration', 'conflict');
+
+-- Drop the old unique index
+DROP INDEX IF EXISTS idx_keyword_feeds_unique;
+
+-- Rename column and change type to UUID
+ALTER TABLE keyword_feeds RENAME COLUMN topic TO topic_id;
+ALTER TABLE keyword_feeds ALTER COLUMN topic_id TYPE uuid USING topic_id::uuid;
+
+-- Add foreign key constraint
+ALTER TABLE keyword_feeds ADD CONSTRAINT fk_keyword_feeds_topic
+    FOREIGN KEY (topic_id) REFERENCES topics(id);
+
+-- Recreate unique index with new column name
+CREATE UNIQUE INDEX idx_keyword_feeds_unique
+ON keyword_feeds (organisation_id, topic_id)
+WHERE is_archived = FALSE;
+
+COMMIT;

--- a/core/migrations/18.keyword-feeds-topic-to-uuid.up.sql
+++ b/core/migrations/18.keyword-feeds-topic-to-uuid.up.sql
@@ -2,14 +2,15 @@ BEGIN;
 
 -- Convert old topic name values to their corresponding UUIDs
 UPDATE keyword_feeds
-SET topic = CASE topic
+SET topic = CASE lower(topic)
     WHEN 'public health' THEN 'bb52f622-b9ee-4d5b-9b70-5fd05046528b'
+    WHEN 'health'        THEN 'bb52f622-b9ee-4d5b-9b70-5fd05046528b'
     WHEN 'eu'            THEN 'ff1bedb9-43e4-49e6-9c3f-27babfb7bfa1'
     WHEN 'climate'       THEN 'db3d996b-e691-4ce5-8c46-e35a82a9b28c'
     WHEN 'migration'     THEN '3cd4a9cd-5906-4b0b-9167-57ff22c2345a'
     WHEN 'conflict'      THEN '0d7aaf8d-5b7e-4c0c-b03a-28457e27ac7d'
 END
-WHERE topic IN ('public health', 'eu', 'climate', 'migration', 'conflict');
+WHERE lower(topic) IN ('health', 'public health', 'eu', 'climate', 'migration', 'conflict');
 
 -- Drop the old unique index
 DROP INDEX IF EXISTS idx_keyword_feeds_unique;

--- a/core/videos/controller.py
+++ b/core/videos/controller.py
@@ -125,7 +125,7 @@ async def extract_transcript_and_claims(
         try:
             org_uuid = UUID(org)
             keyword_feeds = await media_feeds_service.get_keyword_feeds(org_uuid)
-            keywords = {feed.topic: feed.keywords for feed in keyword_feeds}
+            keywords = {str(feed.topic_id): feed.keywords for feed in keyword_feeds}
             if not keywords:
                 log.error(f"org {org} not found")
                 continue

--- a/tests/media_feeds/conftest.py
+++ b/tests/media_feeds/conftest.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import UUID
 
 from litestar import Litestar
 from litestar.testing import AsyncTestClient
@@ -9,6 +10,9 @@ from core.auth.models import Organisation
 from core.auth.service import AuthService
 from core.media_feeds.models import ChannelFeed, KeywordFeed
 from tests.auth.conftest import create_organisation
+
+CLIMATE_TOPIC_ID = UUID("db3d996b-e691-4ce5-8c46-e35a82a9b28c")
+HEALTH_TOPIC_ID = UUID("bb52f622-b9ee-4d5b-9b70-5fd05046528b")
 
 
 class ChannelFeedFactory(ModelFactory[ChannelFeed]):
@@ -56,13 +60,17 @@ async def create_channel_feed(
 async def create_keyword_feed(
     api_key_client: AsyncTestClient[Litestar],
     organisation: Organisation,
+    topic_id: UUID | None = None,
     **kwargs: dict[str, Any],
 ) -> KeywordFeed:
-    keyword_feed = KeywordFeedFactory.build(kwargs=kwargs)
+    feed = KeywordFeedFactory.build(
+        topic_id=topic_id or CLIMATE_TOPIC_ID,
+        kwargs=kwargs,
+    )
     response = await api_key_client.post(
         "/api/media_feeds/keywords",
         params={"organisation_id": str(organisation.id)},
-        json=keyword_feed.model_dump(mode="json"),
+        json=feed.model_dump(mode="json"),
     )
     assert response.status_code == 201
     return KeywordFeed(**response.json()["data"])

--- a/tests/media_feeds/controller_test.py
+++ b/tests/media_feeds/controller_test.py
@@ -9,6 +9,8 @@ from core.auth.service import AuthService
 from core.media_feeds.models import ChannelFeed, KeywordFeed
 from tests.auth.conftest import create_organisation
 from tests.media_feeds.conftest import (
+    CLIMATE_TOPIC_ID,
+    HEALTH_TOPIC_ID,
     ChannelFeedFactory,
     KeywordFeedFactory,
     create_channel_feed,
@@ -252,7 +254,7 @@ async def test_create_keyword_feed(
     api_key_client: AsyncTestClient[Litestar],
     organisation: Organisation,
 ) -> None:
-    keyword_feed = KeywordFeedFactory.build()
+    keyword_feed = KeywordFeedFactory.build(topic_id=CLIMATE_TOPIC_ID)
     keyword_feed_json = keyword_feed.model_dump(
         mode="json", exclude={"id", "created_at", "updated_at"}
     )
@@ -264,7 +266,8 @@ async def test_create_keyword_feed(
     assert response.status_code == 201
     response_data = response.json()["data"]
     assert response_data["organisation_id"] == str(organisation.id)
-    assert response_data["topic"] == keyword_feed.topic
+    assert response_data["topic_id"] == str(CLIMATE_TOPIC_ID)
+    assert response_data["topic_name"] == "Climate"
     assert response_data["keywords"] == keyword_feed.keywords
     assert response_data["is_archived"] is False
 
@@ -274,7 +277,7 @@ async def test_create_keyword_feed_conflict(
     organisation: Organisation,
 ) -> None:
     keyword_feed_data = {
-        "topic": "test_topic",
+        "topic_id": str(CLIMATE_TOPIC_ID),
         "keywords": ["keyword1", "keyword2"],
         "is_archived": False,
     }
@@ -301,9 +304,9 @@ async def test_get_keyword_feeds_by_organisation(
     org1 = await create_organisation(auth_service)
     org2 = await create_organisation(auth_service)
 
-    await create_keyword_feed(api_key_client, organisation=org1)
-    await create_keyword_feed(api_key_client, organisation=org1)
-    await create_keyword_feed(api_key_client, organisation=org2)
+    await create_keyword_feed(api_key_client, organisation=org1, topic_id=CLIMATE_TOPIC_ID)
+    await create_keyword_feed(api_key_client, organisation=org1, topic_id=HEALTH_TOPIC_ID)
+    await create_keyword_feed(api_key_client, organisation=org2, topic_id=CLIMATE_TOPIC_ID)
 
     response = await api_key_client.get(
         "/api/media_feeds/keywords",
@@ -323,9 +326,9 @@ async def test_get_keyword_feeds_without_organisation_filter(
     org1 = await create_organisation(auth_service)
     org2 = await create_organisation(auth_service)
 
-    await create_keyword_feed(api_key_client, organisation=org1)
-    await create_keyword_feed(api_key_client, organisation=org1)
-    await create_keyword_feed(api_key_client, organisation=org2)
+    await create_keyword_feed(api_key_client, organisation=org1, topic_id=CLIMATE_TOPIC_ID)
+    await create_keyword_feed(api_key_client, organisation=org1, topic_id=HEALTH_TOPIC_ID)
+    await create_keyword_feed(api_key_client, organisation=org2, topic_id=CLIMATE_TOPIC_ID)
 
     response = await api_key_client.get("/api/media_feeds/keywords")
     assert response.status_code == 200
@@ -343,7 +346,7 @@ async def test_update_keyword_feed(
     organisation: Organisation,
 ) -> None:
     updated_data = {
-        "topic": "updated_topic",
+        "topic_id": str(HEALTH_TOPIC_ID),
         "keywords": ["new_keyword1", "new_keyword2"],
     }
 
@@ -354,7 +357,8 @@ async def test_update_keyword_feed(
     )
     assert response.status_code == 200
     response_data = response.json()["data"]
-    assert response_data["topic"] == "updated_topic"
+    assert response_data["topic_id"] == str(HEALTH_TOPIC_ID)
+    assert response_data["topic_name"] == "Health"
     assert response_data["keywords"] == ["new_keyword1", "new_keyword2"]
 
 
@@ -364,7 +368,7 @@ async def test_update_keyword_feed_not_found(
 ) -> None:
     non_existent_id = uuid.uuid4()
     updated_data = {
-        "topic": "updated_topic",
+        "topic_id": str(HEALTH_TOPIC_ID),
         "keywords": ["new_keyword1", "new_keyword2"],
     }
 
@@ -408,7 +412,7 @@ async def test_get_organisation_feeds(
     org2 = await create_organisation(auth_service)
 
     await create_channel_feed(api_key_client, organisation=org1)
-    await create_keyword_feed(api_key_client, organisation=org1)
+    await create_keyword_feed(api_key_client, organisation=org1, topic_id=CLIMATE_TOPIC_ID)
     await create_channel_feed(api_key_client, organisation=org2)
 
     response = await api_key_client.get(
@@ -449,9 +453,9 @@ async def test_get_all_feeds(
     org2 = await create_organisation(auth_service)
 
     await create_channel_feed(api_key_client, organisation=org1)
-    await create_keyword_feed(api_key_client, organisation=org1)
+    await create_keyword_feed(api_key_client, organisation=org1, topic_id=CLIMATE_TOPIC_ID)
     await create_channel_feed(api_key_client, organisation=org2)
-    await create_keyword_feed(api_key_client, organisation=org2)
+    await create_keyword_feed(api_key_client, organisation=org2, topic_id=CLIMATE_TOPIC_ID)
 
     response = await api_key_client.get("/api/media_feeds/all")
     assert response.status_code == 200


### PR DESCRIPTION
Fixes https://linear.app/fullfact/issue/AI-2037/pas-topics-are-confudled-by-topic-name-and-id-mismatches

---


> [!CAUTION]
> This will almost certainly require a frontend update to work correctly.

This PR:
1) Updates existing keyword feeds to use topic_ids instead of topic names and maps between them
2) Updates the media_feeds API to include a topic name for display purposes.
