### PR TITLE
refactor: unlink claims to narratives

### DIFF
--- a/core/narratives/api.py
+++ b/core/narratives/api.py
@@ -99,3 +99,18 @@ class NarrativesApiClient:
             return await client.post(
                 url, json=payload, headers=self._headers(), timeout=TIMEOUT
             )
+    
+    async def delete_claim_on_narrative(
+        self,
+        narrative_id: UUID,
+        claim_id: UUID,
+    ) -> httpx.Response:
+        """
+        Delete a claim from a narrative on the narratives service. 
+        This is used when a claim is unlinked from a narrative in our system, so we need to tell the narratives service to remove it from their system as well to keep things in sync.
+        """
+        url = f"{NARRATIVES_BASE_URL}/narrative/{narrative_id}/claim/{claim_id}"
+        async with httpx.AsyncClient() as client:
+            return await client.delete(
+                url, headers=self._headers(), timeout=TIMEOUT
+            )

--- a/core/narratives/controller.py
+++ b/core/narratives/controller.py
@@ -280,3 +280,19 @@ class NarrativeController(Controller):
         narrative_id: UUID,
     ) -> None:
         await narrative_service.delete_narrative(narrative_id)
+
+    @delete(
+        path="/{narrative_id:uuid}/claims/{claim_id:uuid}",
+        summary="Delete a specific claim from a narrative",
+        guards=[super_admin],
+    )
+    async def delete_claim_from_narrative(
+        self,
+        narrative_service: NarrativeService,
+        narrative_id: UUID,
+        claim_id: UUID,
+    ) -> None:
+        try:
+            await narrative_service.delete_claim_from_narrative(narrative_id, claim_id)
+        except ValueError:
+            raise NotFoundException()

--- a/core/narratives/controller.py
+++ b/core/narratives/controller.py
@@ -246,6 +246,11 @@ class NarrativeController(Controller):
         narrative_id: UUID,
         data: NarrativePatchInput,
     ) -> JSON[Narrative]:
+        """
+        Update a narrative. 
+        Only fields provided in the request will be updated. For example, if the request only includes a title, then only the title of the narrative will be updated and all other fields (description, narrative_context, claim_ids, topic_ids, entity_ids) will remain unchanged. 
+        This endpoint is used to unlink claims from a narrative by omitting them from the request, so we need to make sure that if they are omitted, we don't set them to empty lists or null values, but rather leave them unchanged in the database.
+        """
         narrative = await narrative_service.update_narrative(narrative_id, data)
         if not narrative:
             raise NotFoundException()

--- a/core/narratives/repo.py
+++ b/core/narratives/repo.py
@@ -1600,3 +1600,14 @@ class NarrativeRepository:
             )
 
         return summaries
+
+    async def delete_claim_from_narrative(self, narrative_id: UUID, claim_id: UUID) -> bool:
+        """Remove association of a claim from a narrative."""
+        await self._session.execute(
+            """
+            DELETE FROM claim_narratives
+            WHERE narrative_id = %(narrative_id)s AND claim_id = %(claim_id)s
+            """,
+            {"narrative_id": narrative_id, "claim_id": claim_id},
+        )
+        return True

--- a/core/narratives/service.py
+++ b/core/narratives/service.py
@@ -246,23 +246,10 @@ class NarrativeService:
             if not existing_narrative:
                 return None
 
-            merged_entity_ids = None
+            entity_ids = None
             if data.entities is not None:
                 entity_service = EntityService(self._connection_factory)
                 entity_ids = await entity_service.process_entities(data.entities)
-
-                existing_entity_ids = [entity.id for entity in existing_narrative.entities]
-                merged_entity_ids = list(set(existing_entity_ids + entity_ids))
-
-            merged_claim_ids = data.claim_ids
-            if data.claim_ids is not None:
-                existing_claim_ids = [claim.id for claim in existing_narrative.claims]
-                merged_claim_ids = list(set(existing_claim_ids + data.claim_ids))
-
-            merged_topic_ids = data.topic_ids
-            if data.topic_ids is not None:
-                existing_topic_ids = [topic.id for topic in existing_narrative.topics]
-                merged_topic_ids = list(set(existing_topic_ids + data.topic_ids))
 
             # Concatenate narrative_context with existing one
             merged_narrative_context = None
@@ -277,9 +264,9 @@ class NarrativeService:
                 title=data.title,
                 description=data.description,
                 narrative_context=merged_narrative_context,
-                claim_ids=merged_claim_ids,
-                topic_ids=merged_topic_ids,
-                entity_ids=merged_entity_ids,
+                claim_ids=data.claim_ids,
+                topic_ids=data.topic_ids,
+                entity_ids=entity_ids,
                 metadata=data.metadata,
             )
 

--- a/core/narratives/service.py
+++ b/core/narratives/service.py
@@ -404,12 +404,18 @@ class NarrativeService:
             if not any(claim.id == claim_id for claim in narrative.claims):
                 raise ValueError("claim not associated with narrative")
 
-            if _api.is_configured():
-                response = await _api.delete_claim_on_narrative(narrative_id, claim_id)
+            # The external API identifies narratives by their own id (stored in
+            # metadata.narrative_id), not by our local narrative_id. Resolve it
+            # first, mirroring _delete_external_narrative / _sync_external_narrative.
+            external_narrative_id = narrative.metadata.get("narrative_id")
+            if _api.is_configured() and external_narrative_id:
+                response = await _api.delete_claim_on_narrative(
+                    external_narrative_id, claim_id
+                )
                 if response.status_code == 404:
                     logger.info(
-                        f"Narrative {narrative_id} or claim {claim_id} not found on external API, "
-                        "continuing with local delete"
+                        f"Narrative {external_narrative_id} or claim {claim_id} not found "
+                        "on external API, continuing with local delete"
                     )
                 elif response.status_code >= 400:
                     logger.error(
@@ -418,6 +424,14 @@ class NarrativeService:
                     )
                     response.raise_for_status()
                 else:
-                    logger.info(f"Deleted claim {claim_id} from narrative {narrative_id} on external API")
+                    logger.info(
+                        f"Deleted claim {claim_id} from narrative {external_narrative_id} "
+                        "on external API"
+                    )
+            elif _api.is_configured():
+                logger.warning(
+                    f"Narrative {narrative_id} has no external narrative_id in metadata; "
+                    "skipping external claim delete (local delete only)"
+                )
 
             await repo.delete_claim_from_narrative(narrative_id, claim_id)

--- a/core/narratives/service.py
+++ b/core/narratives/service.py
@@ -258,20 +258,6 @@ class NarrativeService:
                     existing_narrative.narrative_context,
                     data.narrative_context,
                 )
-            
-            # If claim_ids are being updated and the new list is shorter than the existing list, it means claims are being removed from the narrative
-            # so we need to call the external API to delete those claims from the narrative on the external service as well to keep them in sync
-            if data.claim_ids is not None and len(existing_narrative.claims) > len(data.claim_ids):
-                logger.info(
-                    f"Claims will be removed from narrative {narrative_id}. Existing claim IDs: {[claim.id for claim in existing_narrative.claims]}, new claim IDs: {data.claim_ids}"
-                )
-                claim_ids_to_remove = set(claim.id for claim in existing_narrative.claims) - set(data.claim_ids)
-                logger.info(f"Removed claim IDs: {claim_ids_to_remove}")
-
-                for claim_id in claim_ids_to_remove:
-                    await self._delete_claim_on_external_narrative(
-                        narrative_id=narrative_id, claim_id=claim_id
-                    )
 
             updated = await repo.update_narrative(
                 narrative_id=narrative_id,
@@ -328,29 +314,6 @@ class NarrativeService:
             response.raise_for_status()
 
         logger.info(f"Deleted narrative {external_narrative_id} from external API")
-
-    async def _delete_claim_on_external_narrative(self, narrative_id: UUID, claim_id: UUID) -> None:
-        """Delete a claim from a narrative on the external narratives API."""
-        if not _api.is_configured():
-            return
-
-        response = await _api.delete_claim_on_narrative(narrative_id, claim_id)
-
-        if response.status_code == 404:
-            logger.info(
-                f"Claim {claim_id} on narrative {narrative_id} not found on external API, "
-                "continuing with local update"
-            )
-            return
-
-        if response.status_code >= 400:
-            logger.error(
-                f"External API delete claim error: status={response.status_code}, "
-                f"response={response.text}"
-            )
-            response.raise_for_status()
-
-        logger.info(f"Deleted claim {claim_id} from narrative {narrative_id} on external API")
     
     async def _sync_external_narrative(
         self,
@@ -437,3 +400,30 @@ class NarrativeService:
             return await repo.get_prevalent_narratives_summary(
                 limit=limit, offset=offset, hours=hours
             )
+
+    async def delete_claim_from_narrative(self, narrative_id: UUID, claim_id: UUID) -> None:
+        async with self.repo() as repo:
+            narrative = await repo.get_narrative(narrative_id)
+            if not narrative:
+                raise ValueError("narrative not found")
+
+            if not any(claim.id == claim_id for claim in narrative.claims):
+                raise ValueError("claim not associated with narrative")
+
+            if _api.is_configured():
+                response = await _api.delete_claim_on_narrative(narrative_id, claim_id)
+                if response.status_code == 404:
+                    logger.info(
+                        f"Narrative {narrative_id} or claim {claim_id} not found on external API, "
+                        "continuing with local delete"
+                    )
+                elif response.status_code >= 400:
+                    logger.error(
+                        f"External API delete error: status={response.status_code}, "
+                        f"response={response.text}"
+                    )
+                    response.raise_for_status()
+                else:
+                    logger.info(f"Deleted claim {claim_id} from narrative {narrative_id} on external API")
+
+            await repo.delete_claim_from_narrative(narrative_id, claim_id)

--- a/core/narratives/service.py
+++ b/core/narratives/service.py
@@ -258,6 +258,20 @@ class NarrativeService:
                     existing_narrative.narrative_context,
                     data.narrative_context,
                 )
+            
+            # If claim_ids are being updated and the new list is shorter than the existing list, it means claims are being removed from the narrative
+            # so we need to call the external API to delete those claims from the narrative on the external service as well to keep them in sync
+            if data.claim_ids is not None and len(existing_narrative.claims) > len(data.claim_ids):
+                logger.info(
+                    f"Claims will be removed from narrative {narrative_id}. Existing claim IDs: {[claim.id for claim in existing_narrative.claims]}, new claim IDs: {data.claim_ids}"
+                )
+                claim_ids_to_remove = set(claim.id for claim in existing_narrative.claims) - set(data.claim_ids)
+                logger.info(f"Removed claim IDs: {claim_ids_to_remove}")
+
+                for claim_id in claim_ids_to_remove:
+                    await self._delete_claim_on_external_narrative(
+                        narrative_id=narrative_id, claim_id=claim_id
+                    )
 
             updated = await repo.update_narrative(
                 narrative_id=narrative_id,
@@ -315,6 +329,29 @@ class NarrativeService:
 
         logger.info(f"Deleted narrative {external_narrative_id} from external API")
 
+    async def _delete_claim_on_external_narrative(self, narrative_id: UUID, claim_id: UUID) -> None:
+        """Delete a claim from a narrative on the external narratives API."""
+        if not _api.is_configured():
+            return
+
+        response = await _api.delete_claim_on_narrative(narrative_id, claim_id)
+
+        if response.status_code == 404:
+            logger.info(
+                f"Claim {claim_id} on narrative {narrative_id} not found on external API, "
+                "continuing with local update"
+            )
+            return
+
+        if response.status_code >= 400:
+            logger.error(
+                f"External API delete claim error: status={response.status_code}, "
+                f"response={response.text}"
+            )
+            response.raise_for_status()
+
+        logger.info(f"Deleted claim {claim_id} from narrative {narrative_id} on external API")
+    
     async def _sync_external_narrative(
         self,
         external_narrative_id: str,

--- a/tests/narratives/conftest.py
+++ b/tests/narratives/conftest.py
@@ -32,7 +32,8 @@ def tables_to_truncate() -> list[str]:
         "narrative_entities",
         "claim_narratives",
         "claim_entities",
-        "claim_topics"
+        "claim_topics",
+        "videos",
     ]
 
 

--- a/tests/narratives/test_narratives_controller.py
+++ b/tests/narratives/test_narratives_controller.py
@@ -793,3 +793,97 @@ async def test_get_narrative_stats_not_found(
     response = await api_key_client.get(f"/api/narratives/{fake_id}/stats")
 
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Delete claim from narrative
+# ---------------------------------------------------------------------------
+
+async def test_delete_claim_from_narrative(
+    api_key_client: AsyncTestClient[Litestar],
+) -> None:
+    _, claim_ids = await _create_video_with_claims(api_key_client, n=2)
+    claim_id_1, claim_id_2 = claim_ids
+
+    create_resp = await api_key_client.post(
+        "/api/narratives/",
+        json=NarrativeInput(
+            title="Delete Claim Test",
+            description="Testing claim deletion",
+            claim_ids=claim_ids,
+        ).model_dump(mode="json"),
+    )
+    assert create_resp.status_code == 201
+    narrative_id = create_resp.json()["data"]["id"]
+
+    response = await api_key_client.delete(
+        f"/api/narratives/{narrative_id}/claims/{claim_id_1}"
+    )
+
+    assert response.status_code == 204
+
+    # Verify claim_id_1 is no longer associated but claim_id_2 remains
+    get_resp = await api_key_client.get(f"/api/narratives/{narrative_id}")
+    assert get_resp.status_code == 200
+    remaining_claim_ids = {c["id"] for c in get_resp.json()["data"]["claims"]}
+    assert str(claim_id_1) not in remaining_claim_ids
+    assert str(claim_id_2) in remaining_claim_ids
+
+
+async def test_delete_claim_from_narrative_narrative_not_found(
+    api_key_client: AsyncTestClient[Litestar],
+) -> None:
+    fake_narrative_id = uuid4()
+    fake_claim_id = uuid4()
+
+    response = await api_key_client.delete(
+        f"/api/narratives/{fake_narrative_id}/claims/{fake_claim_id}"
+    )
+
+    assert response.status_code == 404
+
+
+async def test_delete_claim_from_narrative_claim_not_associated(
+    api_key_client: AsyncTestClient[Litestar],
+    narrative: Narrative,
+) -> None:
+    # Use a claim that was never linked to this narrative
+    _, claim_ids = await _create_video_with_claims(api_key_client, n=1)
+    unrelated_claim_id = claim_ids[0]
+
+    response = await api_key_client.delete(
+        f"/api/narratives/{narrative.id}/claims/{unrelated_claim_id}"
+    )
+
+    assert response.status_code == 404
+
+
+async def test_delete_claim_from_narrative_idempotent_other_claims_intact(
+    api_key_client: AsyncTestClient[Litestar],
+) -> None:
+    _, claim_ids = await _create_video_with_claims(api_key_client, n=3)
+    claim_id_1, claim_id_2, claim_id_3 = claim_ids
+
+    create_resp = await api_key_client.post(
+        "/api/narratives/",
+        json=NarrativeInput(
+            title="Multi-claim Delete Test",
+            description="Testing that only the target claim is removed",
+            claim_ids=claim_ids,
+        ).model_dump(mode="json"),
+    )
+    assert create_resp.status_code == 201
+    narrative_id = create_resp.json()["data"]["id"]
+
+    # Delete only claim_id_2
+    response = await api_key_client.delete(
+        f"/api/narratives/{narrative_id}/claims/{claim_id_2}"
+    )
+    assert response.status_code == 204
+
+    # claim_id_1 and claim_id_3 must still be associated
+    get_resp = await api_key_client.get(f"/api/narratives/{narrative_id}")
+    remaining_claim_ids = {c["id"] for c in get_resp.json()["data"]["claims"]}
+    assert str(claim_id_1) in remaining_claim_ids
+    assert str(claim_id_2) not in remaining_claim_ids
+    assert str(claim_id_3) in remaining_claim_ids

--- a/tests/narratives/test_narratives_controller.py
+++ b/tests/narratives/test_narratives_controller.py
@@ -233,6 +233,255 @@ async def test_patch_narrative_multiple_fields(
     assert len(response_data["entities"]) >= 1
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _create_video_with_claims(
+    client: AsyncTestClient[Litestar], n: int = 2
+) -> tuple[str, list[UUID]]:
+    """Create a video with *n* claims and return (video_id_str, [claim_id, ...])."""
+    video_resp = await client.post(
+        "/api/videos/",
+        json={
+            "title": f"Claims Test Video {uuid4()}",
+            "description": "Video created for claim_ids patch tests",
+            "platform": "youtube",
+            "source_url": f"https://example.com/{uuid4()}",
+            "destination_path": "",
+            "uploaded_at": None,
+            "metadata": {},
+        },
+    )
+    assert video_resp.status_code == 201
+    video_id = video_resp.json()["data"]["id"]
+
+    claims_resp = await client.post(
+        f"/api/videos/{video_id}/claims",
+        json={
+            "claims": [
+                {
+                    "id": str(uuid4()),
+                    "claim": f"Claim {i}",
+                    "start_time_s": float(i * 10),
+                    "metadata": {},
+                }
+                for i in range(n)
+            ]
+        },
+    )
+    assert claims_resp.status_code == 201
+    claim_ids = [UUID(c["id"]) for c in claims_resp.json()["data"]["claims"]]
+    return video_id, claim_ids
+
+
+# ---------------------------------------------------------------------------
+# Topics: replace and clear
+# ---------------------------------------------------------------------------
+
+async def test_patch_narrative_replaces_topics(
+    api_key_client: AsyncTestClient[Litestar],
+) -> None:
+    climate_id = UUID("db3d996b-e691-4ce5-8c46-e35a82a9b28c")
+    health_id = UUID("bb52f622-b9ee-4d5b-9b70-5fd05046528b")
+
+    create_resp = await api_key_client.post(
+        "/api/narratives/",
+        json=NarrativeInput(
+            title="Topic Replace Test",
+            description="Testing topic replacement",
+            topic_ids=[climate_id, health_id],
+        ).model_dump(mode="json"),
+    )
+    assert create_resp.status_code == 201
+    narrative_id = create_resp.json()["data"]["id"]
+
+    # Patch with only health_id — climate must be removed
+    response = await api_key_client.patch(
+        f"/api/narratives/{narrative_id}",
+        json=NarrativePatchInput(topic_ids=[health_id]).model_dump(
+            mode="json", exclude_unset=True
+        ),
+    )
+
+    assert response.status_code == 200
+    topic_ids_in_response = {t["id"] for t in response.json()["data"]["topics"]}
+    assert len(topic_ids_in_response) == 1
+    assert str(health_id) in topic_ids_in_response
+    assert str(climate_id) not in topic_ids_in_response
+
+
+async def test_patch_narrative_clears_topics(
+    api_key_client: AsyncTestClient[Litestar],
+) -> None:
+    climate_id = UUID("db3d996b-e691-4ce5-8c46-e35a82a9b28c")
+
+    create_resp = await api_key_client.post(
+        "/api/narratives/",
+        json=NarrativeInput(
+            title="Topic Clear Test",
+            description="Testing topic clearing",
+            topic_ids=[climate_id],
+        ).model_dump(mode="json"),
+    )
+    assert create_resp.status_code == 201
+    narrative_id = create_resp.json()["data"]["id"]
+
+    # Patch with empty list — all topics must be removed
+    response = await api_key_client.patch(
+        f"/api/narratives/{narrative_id}",
+        json=NarrativePatchInput(topic_ids=[]).model_dump(
+            mode="json", exclude_unset=True
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["topics"] == []
+
+
+# ---------------------------------------------------------------------------
+# Entities: replace and clear
+# ---------------------------------------------------------------------------
+
+async def test_patch_narrative_replaces_entities(
+    api_key_client: AsyncTestClient[Litestar],
+) -> None:
+    entity_a = EntityInput(
+        wikidata_id="Q501",
+        entity_name="Entity Alpha",
+        entity_type="person",
+        wikidata_info={"label": "Entity Alpha"},
+    )
+    entity_b = EntityInput(
+        wikidata_id="Q502",
+        entity_name="Entity Beta",
+        entity_type="organization",
+        wikidata_info={"label": "Entity Beta"},
+    )
+
+    create_resp = await api_key_client.post(
+        "/api/narratives/",
+        json=NarrativeInput(
+            title="Entity Replace Test",
+            description="Testing entity replacement",
+            entities=[entity_a, entity_b],
+        ).model_dump(mode="json"),
+    )
+    assert create_resp.status_code == 201
+    assert len(create_resp.json()["data"]["entities"]) == 2
+    narrative_id = create_resp.json()["data"]["id"]
+
+    # Patch with only entity_a — entity_b must be removed
+    response = await api_key_client.patch(
+        f"/api/narratives/{narrative_id}",
+        json=NarrativePatchInput(entities=[entity_a]).model_dump(
+            mode="json", exclude_unset=True
+        ),
+    )
+
+    assert response.status_code == 200
+    entities_in_response = response.json()["data"]["entities"]
+    assert len(entities_in_response) == 1
+    assert entities_in_response[0]["name"] == "Entity Alpha"
+
+
+async def test_patch_narrative_clears_entities(
+    api_key_client: AsyncTestClient[Litestar],
+) -> None:
+    entity = EntityInput(
+        wikidata_id="Q503",
+        entity_name="Removable Entity",
+        entity_type="person",
+        wikidata_info={"label": "Removable Entity"},
+    )
+
+    create_resp = await api_key_client.post(
+        "/api/narratives/",
+        json=NarrativeInput(
+            title="Entity Clear Test",
+            description="Testing entity clearing",
+            entities=[entity],
+        ).model_dump(mode="json"),
+    )
+    assert create_resp.status_code == 201
+    narrative_id = create_resp.json()["data"]["id"]
+
+    # Patch with empty list — all entities must be removed
+    response = await api_key_client.patch(
+        f"/api/narratives/{narrative_id}",
+        json=NarrativePatchInput(entities=[]).model_dump(
+            mode="json", exclude_unset=True
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["entities"] == []
+
+
+# ---------------------------------------------------------------------------
+# Claim IDs: replace and clear
+# ---------------------------------------------------------------------------
+
+async def test_patch_narrative_replaces_claim_ids(
+    api_key_client: AsyncTestClient[Litestar],
+) -> None:
+    _, claim_ids = await _create_video_with_claims(api_key_client, n=2)
+    claim_id_1, claim_id_2 = claim_ids
+
+    create_resp = await api_key_client.post(
+        "/api/narratives/",
+        json=NarrativeInput(
+            title="Claim Replace Test",
+            description="Testing claim_ids replacement",
+            claim_ids=claim_ids,
+        ).model_dump(mode="json"),
+    )
+    assert create_resp.status_code == 201
+    assert len(create_resp.json()["data"]["claims"]) == 2
+    narrative_id = create_resp.json()["data"]["id"]
+
+    # Patch with only claim_id_1 — claim_id_2 must be removed
+    response = await api_key_client.patch(
+        f"/api/narratives/{narrative_id}",
+        json=NarrativePatchInput(claim_ids=[claim_id_1]).model_dump(
+            mode="json", exclude_unset=True
+        ),
+    )
+
+    assert response.status_code == 200
+    claims_in_response = response.json()["data"]["claims"]
+    assert len(claims_in_response) == 1
+    assert claims_in_response[0]["id"] == str(claim_id_1)
+
+
+async def test_patch_narrative_clears_claim_ids(
+    api_key_client: AsyncTestClient[Litestar],
+) -> None:
+    _, claim_ids = await _create_video_with_claims(api_key_client, n=2)
+
+    create_resp = await api_key_client.post(
+        "/api/narratives/",
+        json=NarrativeInput(
+            title="Claim Clear Test",
+            description="Testing claim_ids clearing",
+            claim_ids=claim_ids,
+        ).model_dump(mode="json"),
+    )
+    assert create_resp.status_code == 201
+    narrative_id = create_resp.json()["data"]["id"]
+
+    # Patch with empty list — all claims must be removed
+    response = await api_key_client.patch(
+        f"/api/narratives/{narrative_id}",
+        json=NarrativePatchInput(claim_ids=[]).model_dump(
+            mode="json", exclude_unset=True
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["claims"] == []
+
+
 async def test_patch_narrative_metadata(
     api_key_client: AsyncTestClient[Litestar],
     narrative: Narrative


### PR DESCRIPTION
This Pull Requests updates the `PATCH /narratives/{narrative_id:uuid}` endpoint by implementing two relevant changes:

1. Fixes a bug where it didn't allowed to update different lists like entities, topics and claims when the payload was removing objects from the narrative; this was causing a bug on the frontend on the Unlink Claim button from the narratives detail view which triggers a request to the PATCH endpoint sending only the remaining claim ids.
2. Implements claim deletion from narratives on external API to maintain synced data. This will allow the external API to keep track of the current state of the narratives and provide better insights.