### PR TITLE
feat(feedback): narrative feedback summary endpoint + rating in list

### DIFF
--- a/core/feedback/controller.py
+++ b/core/feedback/controller.py
@@ -10,7 +10,11 @@ from core.feedback.models import (
     NarrativeFeedbackInput,
 )
 from core.feedback.service import FeedbackService
-from core.models import ClaimNarrativeFeedback, NarrativeFeedback
+from core.models import (
+    ClaimNarrativeFeedback,
+    NarrativeFeedback,
+    NarrativeFeedbackSummary,
+)
 from core.response import JSON
 from core.uow import ConnectionFactory
 
@@ -66,6 +70,22 @@ class NarrativeFeedbackController(Controller):
         if feedback is None:
             raise NotFoundException(f"No feedback found for narrative {narrative_id}")
         return JSON(feedback)
+
+    @get(
+        path="/summary",
+        summary="Get aggregate feedback for a narrative",
+        description="Retrieve the number of users who rated the narrative and their average score.",
+    )
+    async def get_narrative_feedback_summary(
+        self,
+        feedback_service: FeedbackService,
+        user: User,
+        narrative_id: UUID,
+    ) -> JSON[NarrativeFeedbackSummary]:
+        summary = await feedback_service.get_narrative_feedback_summary(
+            narrative_id=narrative_id
+        )
+        return JSON(summary)
 
 
 class ClaimNarrativeFeedbackController(Controller):

--- a/core/feedback/repo.py
+++ b/core/feedback/repo.py
@@ -3,7 +3,11 @@ from uuid import UUID
 import psycopg
 from psycopg.rows import DictRow
 
-from core.models import ClaimNarrativeFeedback, NarrativeFeedback
+from core.models import (
+    ClaimNarrativeFeedback,
+    NarrativeFeedback,
+    NarrativeFeedbackSummary,
+)
 
 
 class FeedbackRepository:
@@ -51,6 +55,30 @@ class FeedbackRepository:
         )
         row = await self._session.fetchone()
         return NarrativeFeedback(**row) if row else None
+
+    async def get_narrative_feedback_summary(
+        self, narrative_id: UUID
+    ) -> NarrativeFeedbackSummary:
+        """Aggregate feedback for a narrative across all users.
+
+        Each (user_id, narrative_id) pair holds a single upserted row, so the
+        count is the number of distinct users who rated and the average is the
+        mean of their latest scores. Returns count 0 / average None when there
+        is no feedback yet.
+        """
+        await self._session.execute(
+            """
+            SELECT COUNT(*) AS score_count,
+                   AVG(feedback_score)::float AS average_score
+            FROM narrative_feedback
+            WHERE narrative_id = %(narrative_id)s
+            """,
+            {"narrative_id": narrative_id},
+        )
+        row = await self._session.fetchone()
+        if row is None:
+            return NarrativeFeedbackSummary(score_count=0, average_score=None)
+        return NarrativeFeedbackSummary(**row)
 
     # Claim-narrative feedback methods
     async def submit_claim_narrative_feedback(

--- a/core/feedback/service.py
+++ b/core/feedback/service.py
@@ -5,7 +5,11 @@ from uuid import UUID
 from litestar.exceptions import NotFoundException
 
 from core.feedback.repo import FeedbackRepository
-from core.models import ClaimNarrativeFeedback, NarrativeFeedback
+from core.models import (
+    ClaimNarrativeFeedback,
+    NarrativeFeedback,
+    NarrativeFeedbackSummary,
+)
 from core.narratives.api import NarrativesApiClient
 from core.uow import ConnectionFactory, uow
 
@@ -52,6 +56,15 @@ class FeedbackService:
         """Get user's feedback for a narrative"""
         async with self.repo() as repo:
             return await repo.get_narrative_feedback(user_id, narrative_id)
+
+    async def get_narrative_feedback_summary(
+        self, narrative_id: UUID
+    ) -> NarrativeFeedbackSummary:
+        """Get aggregate feedback (count + average) for a narrative"""
+        async with self.repo() as repo:
+            if not await repo.narrative_exists(narrative_id):
+                raise NotFoundException(f"Narrative with id {narrative_id} not found")
+            return await repo.get_narrative_feedback_summary(narrative_id)
 
     # Claim-narrative feedback methods
     async def submit_claim_narrative_feedback(

--- a/core/models.py
+++ b/core/models.py
@@ -97,6 +97,13 @@ class NarrativeFeedback(BaseModel):
     updated_at: datetime | None = None
 
 
+class NarrativeFeedbackSummary(BaseModel):
+    score_count: int = Field(ge=0, description="Number of users who rated the narrative")
+    average_score: float | None = Field(
+        default=None, description="Average feedback score across users (null when none exist)"
+    )
+
+
 class ClaimNarrativeFeedback(BaseModel):
     id: UUID = Field(default_factory=uuid4)
     user_id: UUID

--- a/core/narratives/models.py
+++ b/core/narratives/models.py
@@ -48,6 +48,8 @@ class NarrativeSummary(BaseModel):
     video_count: int = 0
     language_count: int = 0
     entity_count: int = 0
+    score_count: int = 0
+    average_score: float | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/core/narratives/repo.py
+++ b/core/narratives/repo.py
@@ -492,6 +492,15 @@ class NarrativeRepository:
                 JOIN topics t ON nt.topic_id = t.id
                 JOIN filtered_narratives fn ON fn.id = nt.narrative_id
                 GROUP BY nt.narrative_id
+            ),
+            narrative_ratings AS (
+                SELECT
+                    nf.narrative_id,
+                    COUNT(*) as score_count,
+                    AVG(nf.feedback_score)::float as average_score
+                FROM narrative_feedback nf
+                JOIN filtered_narratives fn ON fn.id = nf.narrative_id
+                GROUP BY nf.narrative_id
             )
             SELECT
                 fn.id,
@@ -507,13 +516,16 @@ class NarrativeRepository:
                 COALESCE(nv.total_comments, 0) as total_comments,
                 COALESCE(nv.platforms, ARRAY[]::text[]) as platforms,
                 COALESCE(nl.language_count, 0) as language_count,
-                COALESCE(nen.entity_count, 0) as entity_count
+                COALESCE(nen.entity_count, 0) as entity_count,
+                COALESCE(nr.score_count, 0) as score_count,
+                nr.average_score as average_score
             FROM filtered_narratives fn
             LEFT JOIN narrative_claims nc ON fn.id = nc.narrative_id
             LEFT JOIN narrative_videos nv ON fn.id = nv.narrative_id
             LEFT JOIN narrative_languages nl ON fn.id = nl.narrative_id
             LEFT JOIN narrative_entities nen ON fn.id = nen.narrative_id
             LEFT JOIN narrative_topics_agg nta ON fn.id = nta.narrative_id
+            LEFT JOIN narrative_ratings nr ON fn.id = nr.narrative_id
             ORDER BY fn.created_at DESC
         """
 
@@ -540,6 +552,8 @@ class NarrativeRepository:
                     video_count=row["video_count"] or 0,
                     language_count=row["language_count"] or 0,
                     entity_count=row["entity_count"] or 0,
+                    score_count=row["score_count"] or 0,
+                    average_score=row["average_score"],
                     created_at=row["created_at"],
                     updated_at=row["updated_at"],
                 )

--- a/tests/feedback/conftest.py
+++ b/tests/feedback/conftest.py
@@ -1,0 +1,32 @@
+from pytest import fixture
+
+from core.auth.models import Organisation
+from core.auth.service import AuthService
+from tests.auth.conftest import OrganisationFactory
+
+
+@fixture
+def tables_to_truncate() -> list[str]:
+    # Note: users/organisations are intentionally NOT truncated — the api@pas
+    # seed user (migration 10) backs X-API-TOKEN auth used by api_key_client.
+    # Truncating narrative_feedback + narratives is enough to isolate these tests.
+    return [
+        "narrative_feedback",
+        "narratives",
+        "entities",
+        "narrative_topics",
+        "narrative_entities",
+        "claim_narratives",
+    ]
+
+
+@fixture
+async def auth_service(conn_factory) -> AuthService:
+    return AuthService(conn_factory)
+
+
+@fixture
+async def organisation(auth_service: AuthService) -> Organisation:
+    return await auth_service.create_organisation(
+        OrganisationFactory.build(deactivated=None)
+    )

--- a/tests/feedback/controller_test.py
+++ b/tests/feedback/controller_test.py
@@ -1,0 +1,110 @@
+"""End-to-end tests for the narrative feedback-summary endpoint.
+
+Exercises GET /api/feedback/narratives/{id}/summary, which aggregates the
+narrative_feedback rows (one upserted row per user) into a count + average.
+
+Notes:
+- A single AsyncTestClient (api_key_client) is used throughout. X-API-TOKEN auth
+  resolves to the super-admin api@pas user, which satisfies the endpoint's
+  `user` requirement, so a second authenticated client is unnecessary (and two
+  clients on the same app double-close the connection pool at teardown).
+- Feedback rows are seeded directly through FeedbackRepository rather than via
+  the POST endpoint: in this workspace the external narratives API is
+  configured, so POST feedback would attempt a real outbound call. The summary
+  read path does no outbound call, which is what we test here in isolation.
+"""
+
+from uuid import uuid4
+
+from litestar import Litestar
+from litestar.testing import AsyncTestClient
+
+from core.auth.models import Organisation
+from core.auth.service import AuthService
+from core.feedback.repo import FeedbackRepository
+from core.uow import uow
+from tests.auth.controller_test import create_user_with_password
+from tests.narratives.conftest import create_narrative
+
+
+async def test_summary_aggregates_count_and_average(
+    api_key_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+    conn_factory,
+) -> None:
+    narrative = await create_narrative(api_key_client)
+
+    # Two distinct users rate the same narrative: 0.25 and 0.75 -> avg 0.5
+    async with uow(FeedbackRepository, conn_factory) as repo:
+        for score in (0.25, 0.75):
+            user, _ = await create_user_with_password(auth_service, organisation)
+            await repo.submit_narrative_feedback(user.id, narrative.id, score)
+
+    response = await api_key_client.get(
+        f"/api/feedback/narratives/{narrative.id}/summary"
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    assert data["score_count"] == 2
+    assert data["average_score"] == 0.5
+
+
+async def test_narratives_list_includes_rating_aggregate(
+    api_key_client: AsyncTestClient[Litestar],
+    auth_service: AuthService,
+    organisation: Organisation,
+    conn_factory,
+) -> None:
+    """The narratives list endpoint exposes score_count + average_score per item."""
+    narrative = await create_narrative(api_key_client)
+
+    async with uow(FeedbackRepository, conn_factory) as repo:
+        for score in (0.5, 1.0):
+            user, _ = await create_user_with_password(auth_service, organisation)
+            await repo.submit_narrative_feedback(user.id, narrative.id, score)
+
+    response = await api_key_client.get("/api/narratives/")
+    assert response.status_code == 200, response.text
+    items = {item["id"]: item for item in response.json()["data"]}
+    assert str(narrative.id) in items
+    rated = items[str(narrative.id)]
+    assert rated["score_count"] == 2
+    assert rated["average_score"] == 0.75
+
+
+async def test_narratives_list_unrated_has_null_average(
+    api_key_client: AsyncTestClient[Litestar],
+) -> None:
+    """A narrative with no feedback reports score_count 0 / average_score null."""
+    narrative = await create_narrative(api_key_client)
+
+    response = await api_key_client.get("/api/narratives/")
+    assert response.status_code == 200, response.text
+    items = {item["id"]: item for item in response.json()["data"]}
+    rated = items[str(narrative.id)]
+    assert rated["score_count"] == 0
+    assert rated["average_score"] is None
+
+
+async def test_summary_no_feedback_returns_zero_and_none(
+    api_key_client: AsyncTestClient[Litestar],
+) -> None:
+    narrative = await create_narrative(api_key_client)
+
+    response = await api_key_client.get(
+        f"/api/feedback/narratives/{narrative.id}/summary"
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    assert data["score_count"] == 0
+    assert data["average_score"] is None
+
+
+async def test_summary_unknown_narrative_returns_404(
+    api_key_client: AsyncTestClient[Litestar],
+) -> None:
+    response = await api_key_client.get(
+        f"/api/feedback/narratives/{uuid4()}/summary"
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
Add GET /api/feedback/narratives/{id}/summary returning score_count and average_score aggregated from narrative_feedback (one upserted row per user), with a NotFoundException when the narrative does not exist.

Also surface the same aggregate per item in the narratives list query (get_all_narratives_list) via a narrative_ratings CTE, so NarrativeSummary now carries score_count and average_score without extra per-card requests.

Covered by tests/feedback/controller_test.py (5 tests).