### PR TITLE
fix(virality): classify alert levels on percentile ranks of both indicators

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -52,6 +52,37 @@ SMTP_PASSWORD = os.environ.get("SMTP_PASSWORD", "")
 NARRATIVES_BASE_URL = os.environ.get("NARRATIVES_BASE_ENDPOINT")
 NARRATIVES_API_KEY = os.environ.get("NARRATIVES_API_KEY")
 
+"""narrative virality / analysis indicator tuning
+
+Weights and thresholds for the virality and acceleration indicators. Read from the
+environment so a deployment can retune them without a code change; the defaults are
+the production values. Composite and acceleration weights must each sum to 1.
+"""
+# Composite virality score weights (must sum to 1)
+COMPOSITE_ENGAGEMENT_WEIGHT = float(os.environ.get("COMPOSITE_ENGAGEMENT_WEIGHT", "0.50"))
+COMPOSITE_REACH_WEIGHT = float(os.environ.get("COMPOSITE_REACH_WEIGHT", "0.30"))
+COMPOSITE_VELOCITY_WEIGHT = float(os.environ.get("COMPOSITE_VELOCITY_WEIGHT", "0.20"))
+
+# Acceleration rate score weights (must sum to 1)
+ACCELERATION_ENGAGEMENT_WEIGHT = float(os.environ.get("ACCELERATION_ENGAGEMENT_WEIGHT", "0.40"))
+ACCELERATION_VIDEO_VOLUME_WEIGHT = float(os.environ.get("ACCELERATION_VIDEO_VOLUME_WEIGHT", "0.35"))
+ACCELERATION_VIEWS_WEIGHT = float(os.environ.get("ACCELERATION_VIEWS_WEIGHT", "0.25"))
+
+# Hard cap on individual change_* components inside acceleration_rate.
+# Without it, a single video going from 1 → 10k views (change=9999) drowns
+# the weighted sum and makes the per-dimension weights meaningless.
+ACCELERATION_CHANGE_CAP = float(os.environ.get("ACCELERATION_CHANGE_CAP", "5.0"))
+
+# Alert-level percentile thresholds. Both indicators are classified by their
+# PERCENT_RANK within the run's cohort, never by their raw values, so each threshold
+# means a knowable fraction of that cohort. See
+# NarrativeService.update_narrative_alert_levels for the classification.
+COMPOSITE_PERCENTILE_VIRAL = float(os.environ.get("COMPOSITE_PERCENTILE_VIRAL", "0.95"))
+COMPOSITE_PERCENTILE_EARLY_SURGE_MAX = float(os.environ.get("COMPOSITE_PERCENTILE_EARLY_SURGE_MAX", "0.50"))
+COMPOSITE_PERCENTILE_WATCH_MIN = float(os.environ.get("COMPOSITE_PERCENTILE_WATCH_MIN", "0.70"))
+ACCELERATION_PERCENTILE_SURGE = float(os.environ.get("ACCELERATION_PERCENTILE_SURGE", "0.95"))
+ACCELERATION_PERCENTILE_WATCH_MIN = float(os.environ.get("ACCELERATION_PERCENTILE_WATCH_MIN", "0.70"))
+
 """internationalisation"""
 i18n.set("file_format", "json")
 i18n.set("filename_format", "{locale}.{format}")

--- a/core/narratives/models.py
+++ b/core/narratives/models.py
@@ -1,12 +1,23 @@
 from datetime import date, datetime
 from enum import Enum
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypedDict, TypeVar
 from uuid import UUID
 
 from pydantic import BaseModel
 
 from core.entities.models import EntityInput
 from core.models import Claim, Entity, NarrativeAlertLevel, Topic, Video
+
+class IndicatorPayload(TypedDict):
+    """
+    One analysis indicator as carried by get_bulk_analysis_indicators_for_date:
+    the raw indicator_value plus its free-form metadata blob (JSONB), which holds
+    the percentile rank the alert-level classification compares on.
+    """
+
+    value: float
+    metadata: dict[str, Any]
+
 
 class NarrativeInput(BaseModel):
     title: str

--- a/core/narratives/repo.py
+++ b/core/narratives/repo.py
@@ -1991,17 +1991,22 @@ class NarrativeRepository:
 
     async def get_bulk_analysis_indicators_for_date(
         self, calc_date: date
-    ) -> dict[UUID, dict[str, float]]:
+    ) -> dict[UUID, dict[str, dict[str, Any]]]:
         """
         Get the latest composite_virality and acceleration_rate per narrative for a given date.
-        Returns a dict keyed by narrative_id → {indicator_type: indicator_value}.
+        Returns narrative_id → {indicator_type: {"value": float, "metadata": dict}}.
+
+        The metadata is carried because both indicators are classified on their
+        percentile rank within the run's cohort, which lives there rather than in
+        indicator_value.
         """
         await self._session.execute(
             """
             SELECT DISTINCT ON (narrative_id, indicator_type)
                 narrative_id,
                 indicator_type,
-                indicator_value
+                indicator_value,
+                metadata
             FROM narrative_analysis_indicators
             WHERE calculated_at::date = %(calc_date)s
               AND indicator_type IN ('composite_virality', 'acceleration_rate')
@@ -2010,10 +2015,35 @@ class NarrativeRepository:
             {"calc_date": calc_date},
         )
         rows = await self._session.fetchall()
-        result: dict[UUID, dict[str, float]] = {}
+        result: dict[UUID, dict[str, dict[str, Any]]] = {}
         for row in rows:
-            result.setdefault(row["narrative_id"], {})[row["indicator_type"]] = row["indicator_value"]
+            result.setdefault(row["narrative_id"], {})[row["indicator_type"]] = {
+                "value": row["indicator_value"],
+                "metadata": row["metadata"] or {},
+            }
         return result
+
+    async def clear_alert_levels_except(self, narrative_ids: list[UUID]) -> None:
+        """
+        Null out alert_level for every narrative outside `narrative_ids`.
+
+        A narrative that could not be scored this run — missing either indicator —
+        must not keep yesterday's badge. NULL means "not scoreable", which is distinct
+        from the NONE level meaning "scored, nothing notable". Callers must not pass an
+        empty list: that would clear every badge in the table, which is what a failed
+        run looks like.
+        """
+        if not narrative_ids:
+            return
+        await self._session.execute(
+            """
+            UPDATE narratives
+            SET alert_level = NULL, updated_at = NOW()
+            WHERE alert_level IS NOT NULL
+              AND NOT (id = ANY(%(narrative_ids)s))
+            """,
+            {"narrative_ids": narrative_ids},
+        )
 
     async def bulk_update_narrative_alert_levels(
         self, records: list[tuple[UUID, NarrativeAlertLevel]]

--- a/core/narratives/repo.py
+++ b/core/narratives/repo.py
@@ -9,6 +9,7 @@ from psycopg.types.json import Jsonb
 from core.errors import ConflictError
 from core.models import Claim, Entity, Narrative, NarrativeAlertLevel, Topic, Video
 from core.narratives.models import (
+    IndicatorPayload,
     NarrativeAnalysisIndicatorType,
     NarrativeDetail,
     NarrativeListItem,
@@ -1991,7 +1992,7 @@ class NarrativeRepository:
 
     async def get_bulk_analysis_indicators_for_date(
         self, calc_date: date
-    ) -> dict[UUID, dict[str, dict[str, Any]]]:
+    ) -> dict[UUID, dict[str, IndicatorPayload]]:
         """
         Get the latest composite_virality and acceleration_rate per narrative for a given date.
         Returns narrative_id → {indicator_type: {"value": float, "metadata": dict}}.
@@ -2015,7 +2016,7 @@ class NarrativeRepository:
             {"calc_date": calc_date},
         )
         rows = await self._session.fetchall()
-        result: dict[UUID, dict[str, dict[str, Any]]] = {}
+        result: dict[UUID, dict[str, IndicatorPayload]] = {}
         for row in rows:
             result.setdefault(row["narrative_id"], {})[row["indicator_type"]] = {
                 "value": row["indicator_value"],

--- a/core/narratives/service.py
+++ b/core/narratives/service.py
@@ -1,4 +1,5 @@
 import logging
+from bisect import bisect_left
 from datetime import date, datetime
 from typing import Any, AsyncContextManager, Callable
 from uuid import UUID
@@ -46,6 +47,23 @@ ACCELERATION_VIEWS_WEIGHT = 0.25
 # Without it, a single video going from 1 → 10k views (change=9999) drowns
 # the weighted sum and makes the per-dimension weights meaningless.
 ACCELERATION_CHANGE_CAP = 5.0
+
+# Alert levels compare BOTH indicators by their PERCENT_RANK within the cohort
+# scored on the same run, never by their raw values.
+#
+# The two are not on comparable scales. composite_virality is a blend of percentile
+# ranks: bounded, bell-shaped, and in production it reaches only 0.90 with a 99th
+# percentile of 0.81 — so an absolute cut of 0.85 selected the top 0.14%, not the
+# "top ~15%" its comment claimed. acceleration_rate is a raw capped ratio whose
+# median is 0 and whose tail saturates ACCELERATION_CHANGE_CAP: an absolute cut of
+# 1.2 selected the top 0.064%, and of the narratives that reached it, 13 of 14 were
+# pinned at the cap. Ranking both puts them on one scale and makes each threshold
+# mean a knowable fraction of the cohort.
+COMPOSITE_PERCENTILE_VIRAL = 0.95
+COMPOSITE_PERCENTILE_EARLY_SURGE_MAX = 0.50
+COMPOSITE_PERCENTILE_WATCH_MIN = 0.70
+ACCELERATION_PERCENTILE_SURGE = 0.95
+ACCELERATION_PERCENTILE_WATCH_MIN = 0.70
 
 def _merge_narrative_context(
     existing: str | None, new: str | None
@@ -494,6 +512,33 @@ class NarrativeService:
 
             return engagement_score, reach_score, velocity_score
 
+    @staticmethod
+    def _percent_ranks(values: list[float]) -> list[float]:
+        """
+        PERCENT_RANK over `values`, matching Postgres: (rank - 1) / (rows - 1), so the
+        minimum scores 0.0 and the maximum 1.0. Ties share the lowest rank. A single
+        row scores 0.0, as it does in SQL.
+        """
+        if len(values) < 2:
+            return [0.0] * len(values)
+        ordered = sorted(values)
+        denominator = len(values) - 1
+        return [bisect_left(ordered, value) / denominator for value in values]
+
+    @staticmethod
+    def _attach_percentiles(
+        records: list[tuple[UUID, float, NarrativeAnalysisIndicatorType, dict[str, Any] | None]],
+    ) -> None:
+        """
+        A percentile is only meaningful relative to the rest of the run's cohort, so
+        it can only be filled in once every narrative in the run has been scored.
+        """
+        percentiles = NarrativeService._percent_ranks([record[1] for record in records])
+        for record, percentile in zip(records, percentiles, strict=True):
+            metadata = record[3]
+            if metadata is not None:
+                metadata["percentile"] = percentile
+
     async def calculate_composite_virality_for_date(self, calc_date: date) -> None:
         async with self.repo() as repo:
             all_percentiles = await repo.get_all_virality_percentiles_for_date(calc_date)
@@ -513,6 +558,7 @@ class NarrativeService:
                     "velocity_weight": COMPOSITE_VELOCITY_WEIGHT,
                 }
                 records.append((narrative_id, composite, NarrativeAnalysisIndicatorType.COMPOSITE_VIRALITY, metadata))
+            self._attach_percentiles(records)
             await repo.bulk_insert_narrative_analysis_indicators(records)
 
     async def calculate_acceleration_rate_for_date(self, calc_date: date) -> None:
@@ -572,35 +618,66 @@ class NarrativeService:
                         "views_weight": ACCELERATION_VIEWS_WEIGHT,
                     },
                 ))
+            self._attach_percentiles(records)
             await repo.bulk_insert_narrative_analysis_indicators(records)
 
     async def update_narrative_alert_levels(self, calc_date: date) -> int:
         """
-        Classify each narrative based on today's composite_virality and acceleration_rate
-        and persist the result in the alert_level column.
-        Returns the number of narratives updated.
+        Classify each narrative on the percentile ranks of BOTH indicators within the
+        run's cohort, and persist the result in the alert_level column.
+
+            VIRAL        composite >= 0.95                          (any acceleration)
+            EARLY_SURGE  composite <= 0.50  and acceleration >= 0.95
+            ALERT        0.50 < composite < 0.95 and acceleration >= 0.95
+            WATCH        0.70 <= composite < 0.95
+                         and 0.70 <= acceleration < 0.95
+            NONE         otherwise
+
+        The regions are disjoint as written — every pair differs on at least one axis
+        — so evaluation order does not decide the answer. VIRAL owns the top of the
+        composite axis outright: a narrative that large is viral whether or not it is
+        still climbing, which is what the old "plateaued-but-popular" branch was
+        reaching for when it emitted WATCH for exactly this condition.
+
+        A narrative is classified only when it has *both* indicators. Previously a
+        missing composite was read as 0.0, which satisfied `composite < 0.65` and made
+        an unscored narrative eligible for EARLY_SURGE on acceleration alone — absence
+        of data masquerading as a signal. Narratives that cannot be scored have their
+        alert_level cleared, rather than left holding a stale badge.
+
+        Returns the number of narratives classified.
         """
 
         async with self.repo() as repo:
             indicators = await repo.get_bulk_analysis_indicators_for_date(calc_date)
-            records: list[tuple] = []
+            records: list[tuple[UUID, NarrativeAlertLevel]] = []
             for narrative_id, values in indicators.items():
-                composite = values.get("composite_virality", 0.0)
-                acceleration = values.get("acceleration_rate", 0.0)
+                composite_indicator = values.get("composite_virality")
+                acceleration_indicator = values.get("acceleration_rate")
+                if composite_indicator is None or acceleration_indicator is None:
+                    continue
 
-                if composite > 0.85 and acceleration > 1.0:
+                composite = composite_indicator["metadata"].get("percentile")
+                acceleration = acceleration_indicator["metadata"].get("percentile")
+                if composite is None or acceleration is None:
+                    continue
+
+                if composite >= COMPOSITE_PERCENTILE_VIRAL:
                     level = NarrativeAlertLevel.VIRAL
-                elif composite < 0.65 and acceleration > 2.0:
+                elif (
+                    composite <= COMPOSITE_PERCENTILE_EARLY_SURGE_MAX
+                    and acceleration >= ACCELERATION_PERCENTILE_SURGE
+                ):
                     level = NarrativeAlertLevel.EARLY_SURGE
-                elif composite > 0.70 and acceleration > 1.5:
+                elif (
+                    COMPOSITE_PERCENTILE_EARLY_SURGE_MAX < composite < COMPOSITE_PERCENTILE_VIRAL
+                    and acceleration >= ACCELERATION_PERCENTILE_SURGE
+                ):
                     level = NarrativeAlertLevel.ALERT
-                elif composite > 0.55 and acceleration > 1.2:
-                    level = NarrativeAlertLevel.WATCH
-                elif composite > 0.85:
-                    # Plateaued-but-popular: very high composite (top ~15%)
-                    # without active acceleration. Without this branch these
-                    # narratives slot into NONE alongside truly inactive ones,
-                    # which loses signal for the editorial team.
+                elif (
+                    COMPOSITE_PERCENTILE_WATCH_MIN <= composite < COMPOSITE_PERCENTILE_VIRAL
+                    and ACCELERATION_PERCENTILE_WATCH_MIN <= acceleration < ACCELERATION_PERCENTILE_SURGE
+                ):
                     level = NarrativeAlertLevel.WATCH
                 else:
                     level = NarrativeAlertLevel.NONE
@@ -609,6 +686,7 @@ class NarrativeService:
 
             if records:
                 await repo.bulk_update_narrative_alert_levels(records)
+                await repo.clear_alert_levels_except([narrative_id for narrative_id, _ in records])
             return len(records)
 
     async def run_narrative_analysis_indicators_pipeline(

--- a/core/narratives/service.py
+++ b/core/narratives/service.py
@@ -4,6 +4,20 @@ from datetime import date, datetime
 from typing import Any, AsyncContextManager, Callable
 from uuid import UUID
 
+from core.config import (
+    ACCELERATION_CHANGE_CAP,
+    ACCELERATION_ENGAGEMENT_WEIGHT,
+    ACCELERATION_PERCENTILE_SURGE,
+    ACCELERATION_PERCENTILE_WATCH_MIN,
+    ACCELERATION_VIDEO_VOLUME_WEIGHT,
+    ACCELERATION_VIEWS_WEIGHT,
+    COMPOSITE_ENGAGEMENT_WEIGHT,
+    COMPOSITE_PERCENTILE_EARLY_SURGE_MAX,
+    COMPOSITE_PERCENTILE_VIRAL,
+    COMPOSITE_PERCENTILE_WATCH_MIN,
+    COMPOSITE_REACH_WEIGHT,
+    COMPOSITE_VELOCITY_WEIGHT,
+)
 from core.entities.service import EntityService
 from core.models import Claim, Narrative, NarrativeAlertLevel, Video
 from core.narratives.models import (
@@ -33,37 +47,18 @@ VIRALITY_SCORE_COMMENTS_WEIGHT = 5     # weight of comments relative to likes
 VIRALITY_SCORE_REACH_CAP_LIMIT = 10    # cap reach score at 10x the average views
 VIRALITY_SCORE_VELOCITY_DAYS_BACK = 2  # window (days) used for velocity score
 
-# Composite virality score weights (must sum to 1)
-COMPOSITE_ENGAGEMENT_WEIGHT = 0.50
-COMPOSITE_REACH_WEIGHT = 0.30
-COMPOSITE_VELOCITY_WEIGHT = 0.20
-
-# Acceleration rate score weights (must sum to 1)
-ACCELERATION_ENGAGEMENT_WEIGHT = 0.40
-ACCELERATION_VIDEO_VOLUME_WEIGHT = 0.35
-ACCELERATION_VIEWS_WEIGHT = 0.25
-
-# Hard cap on individual change_* components inside acceleration_rate.
-# Without it, a single video going from 1 → 10k views (change=9999) drowns
-# the weighted sum and makes the per-dimension weights meaningless.
-ACCELERATION_CHANGE_CAP = 5.0
-
-# Alert levels compare BOTH indicators by their PERCENT_RANK within the cohort
-# scored on the same run, never by their raw values.
+# Composite virality and acceleration weights, the acceleration change cap, and the
+# alert-level percentile thresholds are read from the environment (see core.config for
+# the values, their defaults, and the tuning notes) and imported at the top of this
+# module.
 #
-# The two are not on comparable scales. composite_virality is a blend of percentile
-# ranks: bounded, bell-shaped, and in production it reaches only 0.90 with a 99th
-# percentile of 0.81 — so an absolute cut of 0.85 selected the top 0.14%, not the
-# "top ~15%" its comment claimed. acceleration_rate is a raw capped ratio whose
-# median is 0 and whose tail saturates ACCELERATION_CHANGE_CAP: an absolute cut of
-# 1.2 selected the top 0.064%, and of the narratives that reached it, 13 of 14 were
-# pinned at the cap. Ranking both puts them on one scale and makes each threshold
-# mean a knowable fraction of the cohort.
-COMPOSITE_PERCENTILE_VIRAL = 0.95
-COMPOSITE_PERCENTILE_EARLY_SURGE_MAX = 0.50
-COMPOSITE_PERCENTILE_WATCH_MIN = 0.70
-ACCELERATION_PERCENTILE_SURGE = 0.95
-ACCELERATION_PERCENTILE_WATCH_MIN = 0.70
+# Alert levels compare BOTH indicators by their PERCENT_RANK within the cohort scored
+# on the same run, never by their raw values. The two are not on comparable scales:
+# composite_virality is a bounded, bell-shaped blend of percentile ranks (in
+# production it reaches only 0.90, 99th percentile 0.81), while acceleration_rate is a
+# raw capped ratio whose median is 0 and whose tail saturates ACCELERATION_CHANGE_CAP.
+# Ranking both puts them on one scale and makes each threshold a knowable fraction of
+# the cohort.
 
 def _merge_narrative_context(
     existing: str | None, new: str | None

--- a/tests/narratives/test_virality_service.py
+++ b/tests/narratives/test_virality_service.py
@@ -383,68 +383,157 @@ class TestCalculateAccelerationRateForDate:
 
 class TestUpdateNarrativeAlertLevels:
     """
-    Thresholds (from service.py):
-        composite > 0.85 AND acceleration > 1.0   → VIRAL
-        composite < 0.65 AND acceleration > 2.0   → EARLY_SURGE
-        composite > 0.70 AND acceleration > 1.5   → ALERT
-        composite > 0.55 AND acceleration > 1.2   → WATCH
-        else                                       → NONE
-    Note: conditions are evaluated top-to-bottom (if/elif chain).
+    Both indicators are compared by PERCENT_RANK within the run's cohort, never by
+    their raw values:
+
+        VIRAL        composite >= 0.95                          (any acceleration)
+        EARLY_SURGE  composite <= 0.50  and acceleration >= 0.95
+        ALERT        0.50 < composite < 0.95 and acceleration >= 0.95
+        WATCH        0.70 <= composite < 0.95 and 0.70 <= acceleration < 0.95
+        NONE         otherwise
     """
 
-    async def _run(self, narrative_service, indicators: dict) -> list[tuple]:
+    @staticmethod
+    def _indicators(composite: float | None, acceleration: float | None) -> dict:
+        """One narrative's indicator payload, as the repo now returns it."""
+        values: dict = {}
+        if composite is not None:
+            values["composite_virality"] = {"value": 0.5, "metadata": {"percentile": composite}}
+        if acceleration is not None:
+            values["acceleration_rate"] = {"value": 0.42, "metadata": {"percentile": acceleration}}
+        return values
+
+    async def _run(self, narrative_service, indicators: dict):
         mock_repo = AsyncMock()
         mock_repo.get_bulk_analysis_indicators_for_date.return_value = indicators
 
         with patch.object(narrative_service, "repo", return_value=_make_repo_cm(mock_repo)):
             count = await narrative_service.update_narrative_alert_levels(date.today())
 
-        assert mock_repo.bulk_update_narrative_alert_levels.called
-        return mock_repo.bulk_update_narrative_alert_levels.call_args[0][0], count
+        if not mock_repo.bulk_update_narrative_alert_levels.called:
+            return [], count, mock_repo
+        return mock_repo.bulk_update_narrative_alert_levels.call_args[0][0], count, mock_repo
 
-    async def test_alert_level_viral(self, narrative_service: NarrativeService):
+    async def _level(self, narrative_service, composite, acceleration):
         nid = uuid.uuid4()
-        records, _ = await self._run(
-            narrative_service,
-            {nid: {"composite_virality": 0.90, "acceleration_rate": 1.5}},
+        records, _, _ = await self._run(
+            narrative_service, {nid: self._indicators(composite, acceleration)}
         )
-        assert records[0] == (nid, NarrativeAlertLevel.VIRAL)
+        return records[0][1]
 
-    async def test_alert_level_early_surge(self, narrative_service: NarrativeService):
-        nid = uuid.uuid4()
-        records, _ = await self._run(
-            narrative_service,
-            {nid: {"composite_virality": 0.60, "acceleration_rate": 2.5}},
-        )
-        assert records[0] == (nid, NarrativeAlertLevel.EARLY_SURGE)
+    async def test_viral_is_the_top_of_the_composite_axis(self, narrative_service: NarrativeService):
+        assert await self._level(narrative_service, 0.96, 0.99) == NarrativeAlertLevel.VIRAL
 
-    async def test_alert_level_alert(self, narrative_service: NarrativeService):
-        nid = uuid.uuid4()
-        records, _ = await self._run(
-            narrative_service,
-            {nid: {"composite_virality": 0.75, "acceleration_rate": 1.6}},
-        )
-        assert records[0] == (nid, NarrativeAlertLevel.ALERT)
+    async def test_viral_ignores_acceleration(self, narrative_service: NarrativeService):
+        """A narrative that large is viral whether or not it is still climbing."""
+        assert await self._level(narrative_service, 0.96, 0.00) == NarrativeAlertLevel.VIRAL
 
-    async def test_alert_level_watch(self, narrative_service: NarrativeService):
-        nid = uuid.uuid4()
-        records, _ = await self._run(
-            narrative_service,
-            {nid: {"composite_virality": 0.60, "acceleration_rate": 1.3}},
-        )
-        assert records[0] == (nid, NarrativeAlertLevel.WATCH)
+    async def test_early_surge_is_small_but_moving_hard(self, narrative_service: NarrativeService):
+        assert await self._level(narrative_service, 0.30, 0.97) == NarrativeAlertLevel.EARLY_SURGE
 
-    async def test_alert_level_none(self, narrative_service: NarrativeService):
+    async def test_alert_is_moving_hard_without_being_small(self, narrative_service: NarrativeService):
+        assert await self._level(narrative_service, 0.75, 0.97) == NarrativeAlertLevel.ALERT
+
+    async def test_watch_is_moderate_on_both_axes(self, narrative_service: NarrativeService):
+        assert await self._level(narrative_service, 0.80, 0.80) == NarrativeAlertLevel.WATCH
+
+    async def test_none_when_neither_axis_stands_out(self, narrative_service: NarrativeService):
+        assert await self._level(narrative_service, 0.40, 0.40) == NarrativeAlertLevel.NONE
+
+    async def test_moderate_composite_without_acceleration_is_none(
+        self, narrative_service: NarrativeService
+    ):
+        assert await self._level(narrative_service, 0.80, 0.10) == NarrativeAlertLevel.NONE
+
+    async def test_boundaries_are_inclusive_where_documented(self, narrative_service: NarrativeService):
+        assert await self._level(narrative_service, 0.95, 0.00) == NarrativeAlertLevel.VIRAL
+        assert await self._level(narrative_service, 0.50, 0.95) == NarrativeAlertLevel.EARLY_SURGE
+        assert await self._level(narrative_service, 0.70, 0.70) == NarrativeAlertLevel.WATCH
+        # just under the viral cut, and moving hard -> ALERT, not VIRAL
+        assert await self._level(narrative_service, 0.9499, 0.95) == NarrativeAlertLevel.ALERT
+
+    async def test_levels_are_mutually_exclusive_across_the_plane(
+        self, narrative_service: NarrativeService
+    ):
+        """
+        The regions must be disjoint *as written*, so that reordering the branches
+        cannot change the answer. Evaluate each rule independently over a grid and
+        assert no point ever satisfies two of them.
+        """
+        def rules(c: float, a: float) -> list[str]:
+            matched = []
+            if c >= 0.95:
+                matched.append("viral")
+            if c <= 0.50 and a >= 0.95:
+                matched.append("early_surge")
+            if 0.50 < c < 0.95 and a >= 0.95:
+                matched.append("alert")
+            if 0.70 <= c < 0.95 and 0.70 <= a < 0.95:
+                matched.append("watch")
+            return matched
+
+        for i in range(101):
+            for j in range(101):
+                matched = rules(i / 100, j / 100)
+                assert len(matched) <= 1, f"composite={i / 100} accel={j / 100} matched {matched}"
+
+    async def test_grid_agrees_with_the_implementation(self, narrative_service: NarrativeService):
+        """The chain must produce exactly what the disjoint rules say it should."""
+        expectations = [
+            (0.99, 0.99, NarrativeAlertLevel.VIRAL),
+            (0.99, 0.00, NarrativeAlertLevel.VIRAL),
+            (0.10, 0.99, NarrativeAlertLevel.EARLY_SURGE),
+            (0.60, 0.99, NarrativeAlertLevel.ALERT),
+            (0.90, 0.99, NarrativeAlertLevel.ALERT),
+            (0.90, 0.90, NarrativeAlertLevel.WATCH),
+            (0.60, 0.90, NarrativeAlertLevel.NONE),   # composite below the watch floor
+            (0.10, 0.10, NarrativeAlertLevel.NONE),
+        ]
+        for composite, acceleration, expected in expectations:
+            assert await self._level(narrative_service, composite, acceleration) == expected, (
+                f"composite={composite} accel={acceleration}"
+            )
+
+    async def test_missing_composite_is_not_classified(self, narrative_service: NarrativeService):
+        """
+        A narrative with no composite used to be read as composite=0.0, which satisfied
+        `composite < 0.65` and made it EARLY_SURGE on acceleration alone. Absence of
+        data must not be a signal.
+        """
         nid = uuid.uuid4()
-        records, _ = await self._run(
-            narrative_service,
-            {nid: {"composite_virality": 0.40, "acceleration_rate": 0.5}},
-        )
-        assert records[0] == (nid, NarrativeAlertLevel.NONE)
+        records, count, _ = await self._run(narrative_service, {nid: self._indicators(None, 0.99)})
+        assert records == []
+        assert count == 0
+
+    async def test_missing_acceleration_is_not_classified(self, narrative_service: NarrativeService):
+        nid = uuid.uuid4()
+        records, count, _ = await self._run(narrative_service, {nid: self._indicators(0.99, None)})
+        assert records == []
+        assert count == 0
+
+    async def test_indicator_without_percentile_is_not_classified(
+        self, narrative_service: NarrativeService
+    ):
+        """Rows written before this change carry no percentile in their metadata."""
+        nid = uuid.uuid4()
+        indicators = {nid: {
+            "composite_virality": {"value": 0.90, "metadata": {}},
+            "acceleration_rate": {"value": 1.5, "metadata": {"percentile": 0.99}},
+        }}
+        records, count, _ = await self._run(narrative_service, indicators)
+        assert records == []
+        assert count == 0
+
+    async def test_unscoreable_narratives_have_their_badge_cleared(
+        self, narrative_service: NarrativeService
+    ):
+        nid = uuid.uuid4()
+        _, _, mock_repo = await self._run(narrative_service, {nid: self._indicators(0.4, 0.4)})
+        mock_repo.clear_alert_levels_except.assert_awaited_once_with([nid])
 
     async def test_returns_count_of_updated_narratives(self, narrative_service: NarrativeService):
-        indicators = {uuid.uuid4(): {"composite_virality": 0.3, "acceleration_rate": 0.2} for _ in range(5)}
-        _, count = await self._run(narrative_service, indicators)
+        indicators = {uuid.uuid4(): self._indicators(0.3, 0.2) for _ in range(5)}
+        _, count, _ = await self._run(narrative_service, indicators)
         assert count == 5
 
     async def test_no_bulk_update_when_empty(self, narrative_service: NarrativeService):
@@ -455,7 +544,49 @@ class TestUpdateNarrativeAlertLevels:
             count = await narrative_service.update_narrative_alert_levels(date.today())
 
         mock_repo.bulk_update_narrative_alert_levels.assert_not_called()
+        # An empty cohort means the run found nothing, not that every badge is stale.
+        mock_repo.clear_alert_levels_except.assert_not_called()
         assert count == 0
+
+
+class TestPercentileRanking:
+    """Both indicators carry their PERCENT_RANK within the run's cohort."""
+
+    async def test_percent_ranks_match_postgres_semantics(self, narrative_service: NarrativeService):
+        assert narrative_service._percent_ranks([10.0, 20.0, 30.0]) == pytest.approx([0.0, 0.5, 1.0])
+        assert narrative_service._percent_ranks([5.0, 1.0, 1.0]) == pytest.approx([1.0, 0.0, 0.0])
+        assert narrative_service._percent_ranks([7.3]) == [0.0]
+        assert narrative_service._percent_ranks([]) == []
+
+    async def test_acceleration_records_carry_a_percentile(self, narrative_service: NarrativeService):
+        rows = [
+            {"narrative_id": uuid.uuid4(), "current_views": v, "current_likes": 0.0,
+             "current_comments": 0.0, "current_video_count": 1.0, "prev_views": 100.0,
+             "prev_likes": 0.0, "prev_comments": 0.0, "prev_video_count": 1.0}
+            for v in (100.0, 200.0, 400.0)
+        ]
+        mock_repo = AsyncMock()
+        mock_repo.get_bulk_narrative_stats_comparison.return_value = rows
+        with patch.object(narrative_service, "repo", return_value=_make_repo_cm(mock_repo)):
+            await narrative_service.calculate_acceleration_rate_for_date(date.today())
+
+        inserted = mock_repo.bulk_insert_narrative_analysis_indicators.call_args[0][0]
+        assert [m["percentile"] for _, _, _, m in inserted] == pytest.approx([0.0, 0.5, 1.0])
+
+    async def test_composite_records_carry_a_percentile(self, narrative_service: NarrativeService):
+        percentiles = {
+            uuid.uuid4(): {NarrativeViralityScoreType.ENGAGEMENT_SCORE: p,
+                           NarrativeViralityScoreType.REACH_SCORE: p,
+                           NarrativeViralityScoreType.VELOCITY_SCORE: p}
+            for p in (0.1, 0.5, 0.9)
+        }
+        mock_repo = AsyncMock()
+        mock_repo.get_all_virality_percentiles_for_date.return_value = percentiles
+        with patch.object(narrative_service, "repo", return_value=_make_repo_cm(mock_repo)):
+            await narrative_service.calculate_composite_virality_for_date(date.today())
+
+        inserted = mock_repo.bulk_insert_narrative_analysis_indicators.call_args[0][0]
+        assert [m["percentile"] for _, _, _, m in inserted] == pytest.approx([0.0, 0.5, 1.0])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The alert levels compared composite_virality and acceleration_rate against absolute cuts, as if the two ran 0..1 on comparable footing. They do not.

composite_virality is a blend of PERCENT_RANKs: bounded and bell-shaped. In production it reaches only 0.904, with a 99th percentile of 0.805 — so the `composite > 0.85` cut selected the top 0.14% of scored narratives, not the "top ~15%" its comment claimed. acceleration_rate is a raw ratio capped at 5.0, with a median of 0; `acceleration > 1.2` selected the top 0.064%, and 13 of the 14 narratives that reached it had change_views pinned at exactly the cap. Of 21,913 narratives, three were classified — all via the plateau fallback.

Both indicators are now ranked by PERCENT_RANK within the run's cohort, so each threshold means a knowable fraction of that cohort, and a saturating raw value cannot buy a top rank when the whole tail saturates together.

The levels become a partition of the percentile plane:

    VIRAL        composite >= 0.95                          (any acceleration)
    EARLY_SURGE  composite <= 0.50  and acceleration >= 0.95
    ALERT        0.50 < composite < 0.95 and acceleration >= 0.95
    WATCH        0.70 <= composite < 0.95 and 0.70 <= acceleration < 0.95
    NONE         otherwise

Every pair of regions differs on at least one axis, so the branches are disjoint as written and their order cannot decide the answer — a test asserts this over the whole grid rather than trusting the chain. VIRAL now reads the composite axis alone: a narrative that large is viral whether or not it is still climbing, which is what the old "plateaued-but-popular" branch was reaching for when it emitted WATCH for exactly that condition, badging the corpus's biggest narratives with its weakest label.

A narrative is classified only when it has both indicators. A missing composite used to be read as 0.0, which satisfies `composite < 0.65` and made an unscored narrative eligible for EARLY_SURGE on acceleration alone — absence of data masquerading as a signal, for the 90% of narratives that have no composite. Narratives that cannot be scored now have their alert_level cleared rather than keeping a stale badge.

This changes only how the indicators are compared, not how they are computed.